### PR TITLE
fix(cluster.py): fixed a bug that caused the IDs to mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drive-ibd"
-version = "2.1.0"
+version = "2.1.1"
 description = "cli tool to identify networks of individuals who share IBD segments overlapping loci of interest"
 authors = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>", "Jennifer E. Below <jennifer.e.below@vumc.org>"]
 maintainers = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>"]


### PR DESCRIPTION
There was a bug where the member_list and the vertex_ids were being flipped incorrectly. This bug was causing the incorrect ids to be mapped back on to grids when the reclustering weas performed. Now that is fixed and results have been compared to the KCNE1 results from DRIVE 1.0.0 to maintain backward compatibility