### PR TITLE
fix(filter.py-and-pyproject.toml): Adjust code so that chromosomes can also use "chr" prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "drive-ibd"
 
-version = "2.7.6"
+version = "2.7.8"
 description = "cli tool to identify networks of individuals who share IBD segments overlapping loci of interest"
 authors = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>", "Jennifer E. Below <jennifer.e.below@vumc.org>"]
 maintainers = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "drive-ibd"
 
-version = "2.7.8"
+version = "2.7.10"
 description = "cli tool to identify networks of individuals who share IBD segments overlapping loci of interest"
 authors = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>", "Jennifer E. Below <jennifer.e.below@vumc.org>"]
 maintainers = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>"]


### PR DESCRIPTION
Sometimes chromosomes in data files are alphanumeric (chr12) instead of just numeric (12). Updated code to check for this. The code adjust the self.target_gene.chr attribute if the chromosome has the chr prefix for downstream filtering use. If neither of the chromosome ids are in the data then DRIVE still raises an ValueError