### PR TITLE
refactor(cluster.py): Changed the minimum network size to be more intuitive and allow reporting of 2 person networks

### DIFF
--- a/drive/cluster/cluster.py
+++ b/drive/cluster/cluster.py
@@ -112,7 +112,7 @@ class ClusterHandler:
         return [
             i
             for i, v in enumerate(random_walk_clusters_sizes)
-            if v > self.min_cluster_size
+            if v >= self.min_cluster_size
         ]
 
     @staticmethod

--- a/drive/drive.py
+++ b/drive/drive.py
@@ -188,7 +188,7 @@ def main() -> None:
 
     parser.add_argument(
         "--min-network-size",
-        default=2,
+        default=3,
         type=int,
         help="This argument sets the minimun network size that we allow. All networks smaller than this size will be filtered out. If the user wishes to keep all networks they can set this to 0. (default: %(default)s)",  # noqa: E501
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "drive-ibd"
 
-version = "2.7.14"
+version = "2.7.15a0"
 description = "cli tool to identify networks of individuals who share IBD segments overlapping loci of interest"
 authors = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>", "Jennifer E. Below <jennifer.e.below@vumc.org>"]
 maintainers = ["James Baker <james.baker@vanderbilt.edu>", "Hung-Hsin Chen <hung-hsin.chen.1@vumc.org>"]


### PR DESCRIPTION
Previously, lines 112-116 in the cluster.py file reported networks that were > than the min_cluster_size. This means that if we wanted networks of size 2 we would have to change this minimum threshold to 1. This design wasn't necessarily intuitive so instead I changed it to be >=. I also change the default value of the min-network-size flag (the flag that sets this attribute) to 3 to preserve legacy behavior by default. The user shouldn't notice a difference. For the moment this is going to be keep at a pre-release level until I verify it is working