### PR TITLE
refactor(pyproject.toml): updated the logging module to pull it from pypi

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs", "notebook"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:3b2548d8352e8b6588ecfb00fb4872d2f68f43744a63035606b3fedc348780be"
+content_hash = "sha256:44b037ac93751a45cf459e60f9669670f568e27346bfcfdb5900b579de15ce1f"
 
 [[metadata.targets]]
 requires_python = ">=3.9,<3.11.0||>3.11.0,<3.12"
@@ -609,15 +609,6 @@ files = [
 ]
 
 [[package]]
-name = "log"
-version = "1.0.0"
-requires_python = ">=3.8"
-git = "https://github.com/jtb324/log.git"
-revision = "7ad614dda296a3a6f938b8b3a82b34a34ce47819"
-summary = "Personal logging abstract from python's logging library that fits my needs"
-groups = ["default"]
-
-[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 requires_python = ">=3.8"
@@ -694,6 +685,17 @@ groups = ["default", "dev"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "modified-logger"
+version = "1.0.0"
+requires_python = ">=3.8"
+summary = "Personal logging abstract from python's logging library that fits my needs"
+groups = ["default"]
+files = [
+    {file = "modified_logger-1.0.0-py3-none-any.whl", hash = "sha256:a2ef6e22fbe9d58609085173839ec130e063d6fbd2acc2b1d1fce19bb9cf8068"},
+    {file = "modified_logger-1.0.0.tar.gz", hash = "sha256:06fdc091b6ba0e9f2e1ba345517c4bfb737988451dff43d6c1aa83c833a3e42e"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "igraph<1.0.0,>=0.10.4",
     "scipy<2.0.0,>=1.10.1",
     "rich-argparse<2.0.0,>=1.3.0",
-    "log @ git+https://github.com/jtb324/log.git",
+    "modified-logger>=1.0.0",
 ]
 
 readme = "README.md"


### PR DESCRIPTION
PYPI wouldn't let me use the logging module from my github so I uploaded it to pypi and then started using that as the dependency in the pyproject.toml