### PR TITLE
Refactor phenotype description parser

### DIFF
--- a/docs/source/inputs_and_outputs/inputs.rst
+++ b/docs/source/inputs_and_outputs/inputs.rst
@@ -54,10 +54,6 @@ Inputs for the clustering subcommand:
 
 ----
 
-* **descriptions**: This argument provides the path to a tab separated text file that contains a text description of each phenotype. This file is typically supplied when the user is running the program phenomewide with PheCodes but can be provided for any phenotype. This file is expected to have two columns called "phecode" and "phenotype"
-
-----
-
 * **max-network-size**: This argument provides one of the thresholds that determines if a network needs to be re-clustered. max-network-size indicates the largest size of a network that is permitted. If a network is bigger than the max-network-size argument and it is smaller than the min-connected-threshold argument then the network will be re-clustered. 
 
 -----
@@ -91,6 +87,10 @@ Inputs for the clustering subcommand:
 ----
 
 * **compress-output**: When DRIVE is run PhenomeWide (especially using the newer PheCode X definitions) the output file from the clustering can become quite large. To help manage file storage the user can compress the output. The output file will be gzipped.
+
+----
+
+* **phecode-categories-to-keep**: This flag is another way for the user to restrict the output of DRIVE. This flag is only really useful if DRIVE is being run phenomewide and for PheCode X. The user can provided the phecode category group and it will keep only phecodes from that category. The value must be spelled exactly how it is spelled in the info files provided by the PheWAS catalogue. DRIVE will still output a minimum phecode column that represents the minimum phecode across all categories. Users can still use their own phecode definitions, DRIVE will just not provide a description name for the custom phenotyping and it can't filter custom phenotyping columns.
 
 ----
 

--- a/src/drive/network/models/data_container.py
+++ b/src/drive/network/models/data_container.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Set, Any
 
+from drive.utilities.parser.phenotype_descriptions_parser import PhecodesMapper
+
 from .networks import Network_Interface
 
 
@@ -12,5 +14,5 @@ class RuntimeState:
     networks: List[Network_Interface]
     output_path: Path
     carriers: Dict[str, Dict[str, Set[str]]]
-    phenotype_descriptions: Dict[str, Dict[str, str]]
+    phenotype_descriptions: PhecodesMapper
     config_options: dict[str, Any] = field(default_factory=dict)

--- a/src/drive/network/network_algorithm.py
+++ b/src/drive/network/network_algorithm.py
@@ -2,6 +2,7 @@ import json
 import re
 from pathlib import Path
 
+from drive.utilities.parser.phenotype_descriptions_parser import PhecodesMapper
 from log import CustomLogger
 
 import drive.network.factory as factory
@@ -9,7 +10,11 @@ from drive.network.cluster import ClusterHandler, cluster
 from drive.network.filters import IbdFilter
 from drive.network.models import RuntimeState, create_indices
 from drive.utilities.functions import split_target_string
-from drive.utilities.parser import PhenotypeFileParser, load_phenotype_descriptions
+from drive.utilities.parser import (
+    PhenotypeFileParser,
+    load_phenotype_descriptions,
+    PhecodesMapper,
+)
 
 logger = CustomLogger.get_logger(__name__)
 
@@ -48,12 +53,12 @@ def run_network_identification(args) -> None:
 
     # we need to load in the phenotype descriptions file to get
     # descriptions of each phenotype
-    if args.descriptions:
-        logger.verbose(f"Using the phenotype descriptions file at: {args.descriptions}")
-        desc_dict = load_phenotype_descriptions(args.descriptions)
-    else:
-        logger.verbose("No phenotype descriptions provided")
-        desc_dict = {}
+    logger.debug("Loading all phecode mappings for versions 1.2 and X")
+    phecodeDescriptions = PhecodesMapper()
+    desc_dict = load_phenotype_descriptions(phecodeDescriptions)
+    logger.debug(
+        f"Loading in mappings for {len(phecodeDescriptions.phecode_names)} phecodes from both versions 1.2 and X"
+    )
 
     # if the user has provided a phenotype file then we will determine case/control/
     # exclusion counts. Otherwise we return an empty dictionary
@@ -115,7 +120,7 @@ def run_network_identification(args) -> None:
         networks,
         args.output,
         phenotype_counts,
-        desc_dict,
+        phecodeDescriptions,
         config_options={
             "compress": args.compress_output,
             "phecode_categories_to_keep": args.phecode_categories_to_keep,

--- a/src/drive/network/network_algorithm.py
+++ b/src/drive/network/network_algorithm.py
@@ -116,7 +116,10 @@ def run_network_identification(args) -> None:
         args.output,
         phenotype_counts,
         desc_dict,
-        config_options={"compress": args.compress_output},
+        config_options={
+            "compress": args.compress_output,
+            "phecode_categories_to_keep": args.phecode_categories_to_keep,
+        },
     )
 
     logger.debug(f"Data container: {plugin_api}")

--- a/src/drive/phecode_mappings/phecode1.2.txt
+++ b/src/drive/phecode_mappings/phecode1.2.txt
@@ -1,0 +1,1867 @@
+phecode	phenotype	category
+008	Intestinal infection	infectious diseases
+008.5	Bacterial enteritis	infectious diseases
+008.51	Intestinal e.coli	infectious diseases
+008.52	Intestinal infection due to C. difficile	infectious diseases
+008.6	Viral Enteritis	infectious diseases
+008.7	Intestinal infection due to protozoa	infectious diseases
+010	Tuberculosis	infectious diseases
+031	Diseases due to other mycobacteria	infectious diseases
+031.1	Leprosy	infectious diseases
+038	Septicemia	infectious diseases
+038.1	Gram negative septicemia	infectious diseases
+038.2	Gram positive septicemia	infectious diseases
+038.3	Bacteremia	infectious diseases
+041	Bacterial infection NOS	infectious diseases
+041.1	Staphylococcus infections	infectious diseases
+041.11	Methicillin sensitive Staphylococcus aureus	infectious diseases
+041.12	Methicillin resistant Staphylococcus aureus	infectious diseases
+041.2	Streptococcus infection	infectious diseases
+041.21	Rheumatic fever / chorea	infectious diseases
+041.4	E. coli	infectious diseases
+041.8	H. pylori	infectious diseases
+041.9	Infection with drug-resistant microorganisms	infectious diseases
+053	Herpes zoster	infectious diseases
+053.1	Herpes zoster with nervous system complications	infectious diseases
+054	Herpes simplex	infectious diseases
+070	Viral hepatitis	infectious diseases
+070.1	Viral hepatitis A	infectious diseases
+070.2	Viral hepatitis B	infectious diseases
+070.3	Viral hepatitis C	infectious diseases
+070.4	Chronic hepatitis	infectious diseases
+070.9	Hepatitis NOS	infectious diseases
+071	Human immunodeficiency virus [HIV] disease	infectious diseases
+071.1	"HIV infection, symptomatic"	infectious diseases
+078	Viral warts & HPV	infectious diseases
+079	Viral infection	infectious diseases
+079.1	Varicella infection	infectious diseases
+079.2	Infectious mononucleosis	infectious diseases
+079.9	"Viremia, NOS"	infectious diseases
+080	Postoperative infection	infectious diseases
+081	Infection/inflammation of internal prosthetic device; implant; and graft	infectious diseases
+081.1	Graft-versus-host disease	infectious diseases
+081.11	Acute graft-versus-host disease	infectious diseases
+081.12	Chronic graft-versus-host disease	infectious diseases
+090	Sexually transmitted infections (not HIV or hepatitis)	infectious diseases
+090.2	Gonococcal infections	infectious diseases
+090.3	Venereal diseases due to Chlamydia trachomatis	infectious diseases
+1000	Burns	NULL
+1001	Foreign body injury	NULL
+1002	"Symptoms concerning nutrition, metabolism, and development"	NULL
+1003	Sudden death	NULL
+1004	Other signs and symptoms involving emotional state	NULL
+1005	Other symptoms	NULL
+1006	Crushing injury	NULL
+1007	Injury to blood vessels	NULL
+1008	Crushing or internal injury to organs	NULL
+1009	"Injury, NOS"	NULL
+1010	Other tests	NULL
+1011	Complications of surgical and medical procedures	NULL
+1012	Late effect	NULL
+1013	Asphyxia and hypoxemia	NULL
+1014	"Effects of heat, cold and air pressure"	NULL
+1015	Effects of other external causes	NULL
+1019	Other ill-defined and unknown causes of morbidity and mortality	NULL
+110	Dermatophytosis / Dermatomycosis	infectious diseases
+110.1	Dermatophytosis	infectious diseases
+110.11	Dermatophytosis of nail	infectious diseases
+110.12	Althete's foot	infectious diseases
+110.13	Dermatophytosis of the body	infectious diseases
+110.2	Dermatomycoses	infectious diseases
+1100	Family history	NULL
+112	Candidiasis	infectious diseases
+112.3	Candidiasis of skin and nails	infectious diseases
+117	Mycoses	infectious diseases
+117.1	Histoplasmosis	infectious diseases
+117.2	Coccidioidomycosis	infectious diseases
+117.3	Blastomycotic infection	infectious diseases
+117.4	Aspergillosis	infectious diseases
+130	Spirochetal infection	infectious diseases
+130.1	Lyme disease	infectious diseases
+131	Protozoan infection	infectious diseases
+132	"Infestation (lice, mites)"	infectious diseases
+132.1	Pediculosis and phthirus infestation	infectious diseases
+133	Arthropod-borne diseases	infectious diseases
+134	Helminthiases	infectious diseases
+134.1	Intestinal helminthiases	infectious diseases
+136	Other infectious and parasitic diseases	infectious diseases
+145	Cancer of mouth	neoplasms
+145.1	Cancer of lip	neoplasms
+145.2	Cancer of tongue	neoplasms
+145.3	Cancer of major salivary glands	neoplasms
+145.4	Cancer of the gums	neoplasms
+145.5	Cancer of the mouth floor	neoplasms
+149	"Cancer of larynx, pharynx, nasal cavities"	neoplasms
+149.1	Cancer of oropharynx	neoplasms
+149.2	Cancer of nasopharynx	neoplasms
+149.3	Cancer of hypopharynx	neoplasms
+149.4	Cancer of larynx	neoplasms
+149.5	Hx of malignant neoplasm of oral cavity and pharynx	neoplasms
+149.9	Cancer of of nasal cavities	neoplasms
+150	Cancer of esophagus	neoplasms
+151	Cancer of stomach	neoplasms
+153	Colorectal cancer	neoplasms
+153.2	Colon cancer	neoplasms
+153.3	"Malignant neoplasm of rectum, rectosigmoid junction, and anus"	neoplasms
+155	Cancer of liver and intrahepatic bile duct	neoplasms
+155.1	"Malignant neoplasm of liver, primary"	neoplasms
+157	Pancreatic cancer	neoplasms
+158	Neoplasm of unspecified nature of digestive system	neoplasms
+159	Malignant neoplasm of other and ill-defined sites within the digestive organs and peritoneum	neoplasms
+159.2	"Malignant neoplasm of small intestine, including duodenum"	neoplasms
+159.3	Malignant neoplasm of gallbladder and extrahepatic bile ducts	neoplasms
+159.4	Malignant neoplasm of retroperitoneum and peritoneum	neoplasms
+164	Cancer of intrathoracic organs	neoplasms
+165	Cancer within the respiratory system	neoplasms
+165.1	Cancer of bronchus; lung	neoplasms
+170	Cancer of bone and connective tissue	neoplasms
+170.1	Bone cancer	neoplasms
+170.2	Cancer of connective tissue	neoplasms
+172	Skin cancer	neoplasms
+172.1	"Melanomas of skin, dx or hx"	neoplasms
+172.11	Melanomas of skin	neoplasms
+172.2	Other non-epithelial cancer of skin	neoplasms
+172.21	Basal cell carcinoma	neoplasms
+172.22	Squamous cell carcinoma	neoplasms
+172.3	Carcinoma in situ of skin	neoplasms
+173	Neoplasm of uncertain behavior of skin	neoplasms
+174	Breast cancer	neoplasms
+174.1	Breast cancer [female]	neoplasms
+174.11	Malignant neoplasm of female breast	neoplasms
+174.2	Breast cancer [male]	neoplasms
+174.3	Neoplasm of uncertain behavior of breast	neoplasms
+175	Acquired absence of breast	neoplasms
+180	Cervical cancer and dysplasia	neoplasms
+180.1	Cervical cancer	neoplasms
+180.3	Cervical intraepithelial neoplasia [CIN] [Cervical dysplasia]	neoplasms
+182	Malignant neoplasm of uterus	neoplasms
+184	Cancer of other female genital organs	neoplasms
+184.1	Malignant neoplasm of ovary and other uterine adnexa	neoplasms
+184.11	Malignant neoplasm of ovary	neoplasms
+184.2	Cancer of other female genital organs (excluding uterus and ovary)	neoplasms
+185	Cancer of prostate	neoplasms
+187	Cancer of other male genital organs	neoplasms
+187.1	Malignant neoplasm of unspecified male genital organ	neoplasms
+187.2	Malignant neoplasm of testis	neoplasms
+187.8	Neoplasm of uncertain behavior of male genital organs	neoplasms
+189	Cancer of urinary organs (incl. kidney and bladder)	neoplasms
+189.1	Cancer of kidney and renal pelvis	neoplasms
+189.11	"Malignant neoplasm of kidney, except pelvis"	neoplasms
+189.12	Malignant neoplasm of renal pelvis	neoplasms
+189.2	Cancer of bladder	neoplasms
+189.21	Malignant neoplasm of bladder	neoplasms
+189.4	Malignant neoplasm of other urinary organs	neoplasms
+190	Cancer of eye	neoplasms
+191	Manlignant and unknown neoplasms of brain and nervous system	neoplasms
+191.1	Cancer of brain and nervous system	neoplasms
+191.11	Cancer of brain	neoplasms
+193	Thyroid cancer	neoplasms
+194	Cancer of other endocrine glands	neoplasms
+195	"Cancer, suspected or other"	neoplasms
+195.1	"Malignant neoplasm, other"	neoplasms
+195.3	"Malignant neoplasm of head, face, and neck"	neoplasms
+196	Radiotherapy	neoplasms
+197	Chemotherapy	neoplasms
+198	Secondary malignant neoplasm	neoplasms
+198.1	Secondary malignancy of lymph nodes	neoplasms
+198.2	Secondary malignancy of respiratory organs	neoplasms
+198.3	Secondary malignant neoplasm of digestive systems	neoplasms
+198.4	Secondary malignant neoplasm of liver	neoplasms
+198.5	Secondary malignancy of brain/spine	neoplasms
+198.6	Secondary malignancy of bone	neoplasms
+198.7	Secondary malignant neoplasm of skin	neoplasms
+199	Neoplasm of uncertain behavior	neoplasms
+199.4	Neurofibromatosis	neoplasms
+200	Myeloproliferative disease	neoplasms
+200.1	Polycythemia vera	neoplasms
+201	Hodgkin's disease	neoplasms
+202	"Cancer of other lymphoid, histiocytic tissue"	neoplasms
+202.2	Non-Hodgkins lymphoma	neoplasms
+202.21	Nodular lymphoma	neoplasms
+202.22	Reticulosarcoma	neoplasms
+202.23	Lymphosarcoma	neoplasms
+202.24	Large cell lymphoma	neoplasms
+204	Leukemia	neoplasms
+204.1	Lymphoid leukemia	neoplasms
+204.11	"Lymphoid leukemia, acute"	neoplasms
+204.12	"Lymphoid leukemia, chronic"	neoplasms
+204.2	Myeloid leukemia	neoplasms
+204.21	"Myeloid leukemia, acute"	neoplasms
+204.22	"Myeloid leukemia, chronic"	neoplasms
+204.3	Monocytic leukemia	neoplasms
+204.4	Multiple myeloma	neoplasms
+208	Benign neoplasm of colon	neoplasms
+209	Neuroendocrine tumors	neoplasms
+210	"Benign neoplasm of lip, oral cavity, and pharynx"	neoplasms
+211	Benign neoplasm of other parts of digestive system	neoplasms
+212	Benign neoplasm of respiratory and intrathoracic organs	neoplasms
+213	Benign neoplasm of bone and articular cartilage	neoplasms
+214	Lipoma	neoplasms
+214.1	Lipoma of skin and subcutaneous tissue	neoplasms
+215	Other benign neoplasm of connective and other soft tissue	neoplasms
+216	Benign neoplasm of skin	neoplasms
+216.1	Screening for malignant neoplasms of the skin	neoplasms
+217	Vascular hamartomas and non-neoplastic nevi	neoplasms
+217.1	"Nevus, non-neoplastic"	neoplasms
+218	Benign neoplasm of uterus	neoplasms
+218.1	Uterine leiomyoma	neoplasms
+218.2	Other benign neoplasm of uterus	neoplasms
+220	Benign neoplasm of ovary	neoplasms
+221	Benign neoplasm of other female genital organs	neoplasms
+222	Benign neoplasm of male genital organs	neoplasms
+223	Benign neoplasm of kidney and other urinary organs	neoplasms
+224	Benign neoplasm of eye	neoplasms
+224.1	"Benign neoplasm of eye, uveal"	neoplasms
+225	Benign neoplasm of brain and other parts of nervous system	neoplasms
+225.1	"Benign neoplasm of brain, cranial nerves, meninges"	neoplasms
+225.2	"Benign neoplasm of spinal cord, meninges"	neoplasms
+226	Benign neoplasm of thyroid glands	neoplasms
+227	Benign neoplasm of other endocrine glands and related structures	neoplasms
+227.1	Benign neoplasm of adrenal gland	neoplasms
+227.2	Benign neoplasm of parathyroid gland	neoplasms
+227.3	Benign neoplasm of pituitary gland and craniopharyngeal duct (pouch)	neoplasms
+228	"Hemangioma and lymphangioma, any site"	neoplasms
+228.1	Hemangioma of skin and subcutaneous tissue	neoplasms
+229	Benign neoplasm of unspecified sites	neoplasms
+229.1	Benign neoplasm of lymph nodes	neoplasms
+230	Kaposi's sarcoma	neoplasms
+240	Simple and unspecified goiter	endocrine/metabolic
+241	Nontoxic nodular goiter	endocrine/metabolic
+241.1	Nontoxic uninodular goiter	endocrine/metabolic
+241.2	Nontoxic multinodular goiter	endocrine/metabolic
+242	Thyrotoxicosis with or without goiter	endocrine/metabolic
+242.1	Graves' disease	endocrine/metabolic
+242.2	Toxic multinodular goiter	endocrine/metabolic
+242.3	Exophthalmos	endocrine/metabolic
+242.31	Thyrotoxic exophthalmos	endocrine/metabolic
+244	Hypothyroidism	endocrine/metabolic
+244.1	Secondary hypothyroidism	endocrine/metabolic
+244.2	Acquired hypothyroidism	endocrine/metabolic
+244.3	Iodine hypothyroidism	endocrine/metabolic
+244.4	Hypothyroidism NOS	endocrine/metabolic
+244.5	Congenital hypothyroidism	endocrine/metabolic
+245	Thyroiditis	endocrine/metabolic
+245.1	"Thyroiditis, acute and subacute"	endocrine/metabolic
+245.2	Chronic thyroiditis	endocrine/metabolic
+245.21	Chronic lymphocytic thyroiditis	endocrine/metabolic
+246	Other disorders of thyroid	endocrine/metabolic
+246.2	Thyroid cyst	endocrine/metabolic
+246.7	Abnormal results of function study of thyroid	endocrine/metabolic
+249	Secondary diabetes mellitus	endocrine/metabolic
+250	Diabetes mellitus	endocrine/metabolic
+250.1	Type 1 diabetes	endocrine/metabolic
+250.11	Type 1 diabetes with ketoacidosis	endocrine/metabolic
+250.12	Type 1 diabetes with renal manifestations	endocrine/metabolic
+250.13	Type 1 diabetes with ophthalmic manifestations	endocrine/metabolic
+250.14	Type 1 diabetes with neurological manifestations	endocrine/metabolic
+250.15	Diabetes type 1 with peripheral circulatory disorders	endocrine/metabolic
+250.2	Type 2 diabetes	endocrine/metabolic
+250.21	Type 2 diabetes with ketoacidosis	endocrine/metabolic
+250.22	Type 2 diabetes with renal manifestations	endocrine/metabolic
+250.23	Type 2 diabetes with ophthalmic manifestations	endocrine/metabolic
+250.24	Type 2 diabetes with neurological manifestations	endocrine/metabolic
+250.25	Diabetes type 2 with peripheral circulatory disorders	endocrine/metabolic
+250.3	Insulin pump user	endocrine/metabolic
+250.4	Abnormal glucose	endocrine/metabolic
+250.41	Impaired fasting glucose	endocrine/metabolic
+250.42	Other abnormal glucose	endocrine/metabolic
+250.5	Glycosuria or Acetonuria	endocrine/metabolic
+250.6	Polyneuropathy in diabetes	endocrine/metabolic
+250.7	Diabetic retinopathy	endocrine/metabolic
+251	Other disorders of pancreatic internal secretion	endocrine/metabolic
+251.1	Hypoglycemia	endocrine/metabolic
+251.8	Abnormality of secretion of glucagon or gastrin	endocrine/metabolic
+252	Disorders of parathyroid gland	endocrine/metabolic
+252.1	Hyperparathyroidism	endocrine/metabolic
+252.2	Hypoparathyroidism	endocrine/metabolic
+253	Disorders of the pituitary gland and its hypothalamic control	endocrine/metabolic
+253.1	Pituitary hyperfunction	endocrine/metabolic
+253.11	Acromegaly and gigantism	endocrine/metabolic
+253.2	Pituitary hypofunction	endocrine/metabolic
+253.3	Diabetes insipidus	endocrine/metabolic
+253.4	Anterior pituitary disorders	endocrine/metabolic
+253.5	Pituitary dwarfism	endocrine/metabolic
+253.7	Other disorders of neurohypophysis	endocrine/metabolic
+254	Diseases of thymus gland	endocrine/metabolic
+255	Disorders of adrenal glands	endocrine/metabolic
+255.1	Adrenal hyperfunction	endocrine/metabolic
+255.11	Cushing's syndrome	endocrine/metabolic
+255.12	Hyperaldosteronism	endocrine/metabolic
+255.13	Medulloadrenal hyperfunction	endocrine/metabolic
+255.2	Adrenal hypofunction	endocrine/metabolic
+255.21	Glucocorticoid deficiency	endocrine/metabolic
+255.22	Mineralocorticoid deficiency	endocrine/metabolic
+255.3	Adrenogenital disorders	endocrine/metabolic
+256	Ovarian dysfunction	endocrine/metabolic
+256.1	Hyperestrogenism	endocrine/metabolic
+256.4	Polycystic ovaries	endocrine/metabolic
+257	Testicular dysfunction	endocrine/metabolic
+257.1	Testicular hypofunction	endocrine/metabolic
+258	Iatrogenic endocrine disorders	endocrine/metabolic
+258.1	Postablative ovarian failure	endocrine/metabolic
+259	Other endocrine disorders	endocrine/metabolic
+259.1	Nonspecific abnormal results of other endocrine function study	endocrine/metabolic
+259.2	Carcinoid syndrome	endocrine/metabolic
+259.3	Delay in sexual development and puberty NEC	endocrine/metabolic
+259.4	Precocious sexual development and puberty NEC	endocrine/metabolic
+259.8	Polyglandular activity in multiple endocrine adenomatosis	endocrine/metabolic
+260	Protein-calorie malnutrition	endocrine/metabolic
+260.1	Cachexia	endocrine/metabolic
+260.2	severe protein-calorie malnutrition	endocrine/metabolic
+260.21	Kwashiorkor	endocrine/metabolic
+260.22	Nutritional marasmus	endocrine/metabolic
+260.3	Adult failure to thrive	endocrine/metabolic
+260.6	Anorexia	endocrine/metabolic
+260.7	Polyphagia	endocrine/metabolic
+261	Vitamin deficiency	endocrine/metabolic
+261.1	Vitamin A deficiency	endocrine/metabolic
+261.2	Vitamin B-complex deficiencies	endocrine/metabolic
+261.3	Vitamin C deficiencies	endocrine/metabolic
+261.4	Vitamin D deficiency	endocrine/metabolic
+261.41	Rickets or osteomalacia	endocrine/metabolic
+262	Mineral deficiency NEC	endocrine/metabolic
+263	Other nutritional deficiency	endocrine/metabolic
+264	Lack of normal physiological development	endocrine/metabolic
+264.1	Short stature	endocrine/metabolic
+264.2	Failure to thrive (childhood)	endocrine/metabolic
+264.3	Delayed milestones	endocrine/metabolic
+264.9	"Lack of normal physiological development, unspecified"	endocrine/metabolic
+269	Proteinuria	endocrine/metabolic
+270	Disorders of protein plasma/amino-acid transport and metabolism	endocrine/metabolic
+270.1	Disturbances of amino-acid transport	endocrine/metabolic
+270.11	Disturbances of sulphur-bearing amino-acid metabolism	endocrine/metabolic
+270.12	Phenylketonuria [PKU]	endocrine/metabolic
+270.2	Disorders of amino-acid metabolism	endocrine/metabolic
+270.21	Disorders of urea cycle metabolism	endocrine/metabolic
+270.3	Disorders of plasma protein metabolism	endocrine/metabolic
+270.31	Polyclonal hypergammaglobulinemia	endocrine/metabolic
+270.32	Paraproteinemia	endocrine/metabolic
+270.33	Amyloidosis	endocrine/metabolic
+270.34	Alpha-1-antitrypsin deficiency	endocrine/metabolic
+270.35	Macroglobulinemia	endocrine/metabolic
+270.38	Other specified disorders of plasma protein metabolism	endocrine/metabolic
+271	Disorders of carbohydrate transport and metabolism	endocrine/metabolic
+271.3	Intestinal disaccharidase deficiencies and disaccharide malabsorption	endocrine/metabolic
+271.9	Other disorders of carbohydrate transport and metabolism	endocrine/metabolic
+272	Disorders of lipoid metabolism	endocrine/metabolic
+272.1	Hyperlipidemia	endocrine/metabolic
+272.11	Hypercholesterolemia	endocrine/metabolic
+272.12	Hyperglyceridemia	endocrine/metabolic
+272.13	Mixed hyperlipidemia	endocrine/metabolic
+272.14	Hyperchylomicronemia	endocrine/metabolic
+272.9	Unspecified disorder of lipoid metabolism	endocrine/metabolic
+274	Gout and other crystal arthropathies	endocrine/metabolic
+274.1	Gout	endocrine/metabolic
+274.11	Gouty arthropathy	endocrine/metabolic
+274.2	Crystal arthropathies	endocrine/metabolic
+274.21	Chondrocalcinosis	endocrine/metabolic
+275	Disorders of mineral metabolism	endocrine/metabolic
+275.1	Disorders of iron metabolism	hematopoietic
+275.11	Hereditary hemochromatosis	hematopoietic
+275.2	Disorders of copper metabolism	endocrine/metabolic
+275.3	Disorders of magnesium metabolism	endocrine/metabolic
+275.5	Disorders of calcium/phosphorus metabolism	endocrine/metabolic
+275.51	Hypocalcemia	endocrine/metabolic
+275.53	Disorders of phosphorus metabolism	endocrine/metabolic
+275.6	Hypercalcemia	endocrine/metabolic
+276	"Disorders of fluid, electrolyte, and acid-base balance"	endocrine/metabolic
+276.1	Electrolyte imbalance	endocrine/metabolic
+276.11	Hyperosmolality and/or hypernatremia	endocrine/metabolic
+276.12	Hyposmolality and/or hyponatremia	endocrine/metabolic
+276.13	Hyperpotassemia	endocrine/metabolic
+276.14	Hypopotassemia	endocrine/metabolic
+276.4	Acid-base balance disorder	endocrine/metabolic
+276.41	Acidosis	endocrine/metabolic
+276.42	Alkalosis	endocrine/metabolic
+276.5	Hypovolemia	endocrine/metabolic
+276.6	Fluid overload	endocrine/metabolic
+276.8	Polydipsia	endocrine/metabolic
+277	Other disorders of metabolism	endocrine/metabolic
+277.1	Disorders of porphyrin metabolism	endocrine/metabolic
+277.2	Other disorders of purine and pyrimidine metabolism	endocrine/metabolic
+277.4	Disorders of bilirubin excretion	endocrine/metabolic
+277.5	Other disorders of lipoid metabolism	endocrine/metabolic
+277.51	Lipoprotein disorders	endocrine/metabolic
+277.6	Other deficiencies of circulating enzymes	endocrine/metabolic
+277.7	Dysmetabolic syndrome X	endocrine/metabolic
+277.8	Carnitine deficiencies	endocrine/metabolic
+278	"Overweight, obesity and other hyperalimentation"	endocrine/metabolic
+278.1	Obesity	endocrine/metabolic
+278.11	Morbid obesity	endocrine/metabolic
+278.3	Localized adiposity	endocrine/metabolic
+278.4	Abnormal weight gain	endocrine/metabolic
+279	Disorders involving the immune mechanism	endocrine/metabolic
+279.1	Immunity deficiency	endocrine/metabolic
+279.11	Deficiency of humoral immunity	endocrine/metabolic
+279.2	Autoimmune disease NEC	endocrine/metabolic
+279.7	Other immunological findings	endocrine/metabolic
+279.8	Other specified disorders involving the immune mechanism	endocrine/metabolic
+280	Iron deficiency anemias	hematopoietic
+280.1	"Iron deficiency anemias, unspecified or not due to blood loss"	hematopoietic
+280.2	Iron deficiency anemia secondary to blood loss (chronic)	hematopoietic
+281	Other deficiency anemia	hematopoietic
+281.1	Megaloblastic anemia	hematopoietic
+281.11	Pernicious anemia	hematopoietic
+281.12	Other vitamin B12 deficiency anemia	hematopoietic
+281.13	Folate-deficiency anemia	hematopoietic
+281.9	Deficiency anemias	hematopoietic
+282	Hereditary hemolytic anemias	hematopoietic
+282.5	Sickle cell anemia	hematopoietic
+282.8	Other hemoglobinopathies	hematopoietic
+282.9	Other hereditary hemolytic anemias	hematopoietic
+283	Acquired hemolytic anemias	hematopoietic
+283.1	Autoimmune hemolytic anemias	hematopoietic
+283.2	Non-autoimmune hemolytic anemias	hematopoietic
+283.21	Hemolytic-uremic syndrome	hematopoietic
+284	Aplastic anemia	hematopoietic
+284.1	Pancytopenia	hematopoietic
+284.2	Constitutional aplastic anemia	hematopoietic
+285	Other anemias	hematopoietic
+285.1	Acute posthemorrhagic anemia	hematopoietic
+285.2	Anemia of chronic disease	hematopoietic
+285.21	Anemia in chronic kidney disease	hematopoietic
+285.22	Anemia in neoplastic disease	hematopoietic
+285.3	Sideroblastic anemia	hematopoietic
+285.8	Hemoglobinuria	hematopoietic
+286	Coagulation defects	hematopoietic
+286.1	Congenital coagulation defects	hematopoietic
+286.11	Von willebrand's disease	hematopoietic
+286.12	Congenital deficiency of other clotting factors (including factor VII)	hematopoietic
+286.13	Congenital factor VIII disorder	hematopoietic
+286.2	Encounter for long-term (current) use of anticoagulants	hematopoietic
+286.3	Coagulation defects complicating pregnancy or postpartum	hematopoietic
+286.4	Acquired coagulation factor deficiency	hematopoietic
+286.5	Hemorrhagic disorder due to intrinsic circulating anticoagulants	hematopoietic
+286.6	Defibrination syndrome	hematopoietic
+286.7	Other and unspecified coagulation defects	hematopoietic
+286.8	Hypercoagulable state	hematopoietic
+286.81	Primary hypercoagulable state	hematopoietic
+286.9	Abnormal coagulation profile	hematopoietic
+287	Purpura and other hemorrhagic conditions	hematopoietic
+287.1	Spontaneous ecchymoses	hematopoietic
+287.2	Allergic purpura	hematopoietic
+287.3	Thrombocytopenia	hematopoietic
+287.31	Primary thrombocytopenia	hematopoietic
+287.32	Secondary thrombocytopenia	hematopoietic
+287.4	Qualitative platelet defects	hematopoietic
+288	Diseases of white blood cells	hematopoietic
+288.1	Decreased white blood cell count	hematopoietic
+288.11	Neutropenia	hematopoietic
+288.2	Elevated white blood cell count	hematopoietic
+288.3	Eosinophilia	hematopoietic
+289	Other diseases of blood and blood-forming organs	hematopoietic
+289.1	Myelofibrosis	hematopoietic
+289.3	Personal history of diseases of blood and blood-forming organs	hematopoietic
+289.4	Lymphadenitis	hematopoietic
+289.5	Diseases of spleen	hematopoietic
+289.8	"Polycythemia, secondary"	hematopoietic
+289.9	Abnormality of red blood cells	hematopoietic
+290	Delirium dementia and amnestic and other cognitive disorders	mental disorders
+290.1	Dementias	mental disorders
+290.11	Alzheimer's disease	mental disorders
+290.12	Dementia with cerebral degenerations	mental disorders
+290.13	Senile dementia	mental disorders
+290.16	Vascular dementia	mental disorders
+290.2	Delirium due to conditions classified elsewhere	mental disorders
+290.3	Other persistent mental disorders due to conditions classified elsewhere	mental disorders
+291	Other specified nonpsychotic and/or transient mental disorders	mental disorders
+291.1	Transient mental disorders due to conditions classified elsewhere	mental disorders
+291.4	Specific nonpsychotic mental disorders due to brain damage	mental disorders
+291.8	Alteration of consciousness	mental disorders
+292	Neurological disorders	mental disorders
+292.1	Aphasia/speech disturbance	mental disorders
+292.11	Aphasia	mental disorders
+292.12	Symbolic dysfunction	mental disorders
+292.2	Mild cognitive impairment	mental disorders
+292.3	Memory loss	mental disorders
+292.4	Altered mental status	mental disorders
+292.5	Transient alteration of awareness	mental disorders
+292.6	Hallucinations	mental disorders
+293	Symptoms involving head and neck	mental disorders
+293.1	"Swelling, mass, or lump in head and neck [Space-occupying lesion, intracranial NOS]"	mental disorders
+295	Schizophrenia and other psychotic disorders	mental disorders
+295.1	Schizophrenia	mental disorders
+295.2	Paranoid disorders	mental disorders
+295.3	Psychosis	mental disorders
+296	Mood disorders	mental disorders
+296.1	Bipolar	mental disorders
+296.2	Depression	mental disorders
+296.22	Major depressive disorder	mental disorders
+297	Suicidal ideation or attempt	mental disorders
+297.1	Suicidal ideation	mental disorders
+297.2	Suicide or self-inflicted injury	mental disorders
+300	Anxiety disorders	mental disorders
+300.1	Anxiety disorder	mental disorders
+300.11	Generalized anxiety disorder	mental disorders
+300.12	"Agorophobia, social phobia, and panic disorder"	mental disorders
+300.13	Phobia	mental disorders
+300.2	Generalized anxiety & phobic disorders	mental disorders
+300.3	Obsessive-compulsive disorders	mental disorders
+300.4	Dysthymic disorder	mental disorders
+300.8	Acute reaction to stress	mental disorders
+300.9	Posttraumatic stress disorder	mental disorders
+301	Personality disorders	mental disorders
+301.1	Schizoid personality disorder	mental disorders
+301.2	Antisocial/borderline personality disorder	mental disorders
+302	Sexual and gender identity disorders	mental disorders
+302.1	Decreased libido	mental disorders
+303	Psychogenic and somatoform disorders	mental disorders
+303.1	Dissociative disorder	mental disorders
+303.3	Psychogenic disorder	mental disorders
+303.31	Gastrointestinal malfunction arising from mental factors	mental disorders
+303.4	Somatoform disorder	mental disorders
+304	Adjustment reaction	mental disorders
+305.2	Eating disorder	mental disorders
+305.21	Anorexia nervosa	mental disorders
+306	Other mental disorder	mental disorders
+306.1	Mental disorders durring/after pregnancy	mental disorders
+306.9	Tension headache	mental disorders
+312	Conduct disorders	mental disorders
+312.3	Impulse control disorder	mental disorders
+313	Pervasive developmental disorders	mental disorders
+313.1	Attention deficit hyperactivity disorder	mental disorders
+313.2	Tics and stuttering	mental disorders
+313.3	Autism	mental disorders
+315	Develomental delays and disorders	mental disorders
+315.1	Learning disorder	mental disorders
+315.2	Speech and language disorder	mental disorders
+315.3	Mental retardation	mental disorders
+316	Substance addiction and disorders	mental disorders
+316.1	Polyneuropathy due to drugs	mental disorders
+317	Alcohol-related disorders	mental disorders
+317.1	Alcoholism	mental disorders
+317.11	Alcoholic liver damage	mental disorders
+318	Tobacco use disorder	mental disorders
+320	Meningitis	neurological
+323	Encephalitis	neurological
+323.2	Acute (transverse) myelitis	neurological
+323.8	"Encephalitis, non-infectious"	neurological
+324	Other CNS infection and poliomyelitis	neurological
+324.1	Jakob-Creutzfeldt disease	neurological
+325	Phlebitis and thrombophlebitis of intracranial venous sinuses	neurological
+327	Sleep disorders	neurological
+327.1	Hypersomnia	neurological
+327.3	Sleep apnea	neurological
+327.31	Central/nonobstroctive sleep apnea	neurological
+327.32	Obstructive sleep apnea	neurological
+327.4	Insomnia	neurological
+327.41	Organic or persistent insomnia	neurological
+327.5	Parasomnia	neurological
+327.6	Circadian rhythm sleep disorder	neurological
+327.7	Sleep related movement disorders	neurological
+327.71	Restless legs syndrome	neurological
+327.72	Sleep related leg cramps	neurological
+331	Other cerebral degenerations	neurological
+331.1	Hydrocephalus	neurological
+331.9	"Cerebral degeneration, unspecified"	neurological
+332	Parkinson's disease	neurological
+333	Extrapyramidal disease and abnormal movement disorders	neurological
+333.1	Essential tremor	neurological
+333.2	Myoclonus	neurological
+333.3	Tics and choreas	neurological
+333.4	Torsion dystonia	neurological
+333.8	Other degenerative diseases of the basal ganglia	neurological
+334	Degenerative disease of the spinal cord	neurological
+334.1	Spinocerebellar disease	neurological
+334.2	Anterior horn cell disease	neurological
+334.21	Amyotrophic Lateral Sclerosis	neurological
+335	Multiple sclerosis	neurological
+337	Disorders of the autonomic nervous system	neurological
+337.1	Peripheral autonomic neuropathy	neurological
+338	Pain	neurological
+338.1	Acute pain	neurological
+338.2	Chronic pain	neurological
+339	Other headache syndromes	neurological
+340	Migraine	neurological
+340.1	Migrain with aura	neurological
+341	Other demyelinating diseases of central nervous system	neurological
+342	Hemiplegia	neurological
+343	Infantile cerebral palsy	neurological
+344	Other paralytic syndromes	neurological
+345	"Epilepsy, recurrent seizures, convulsions"	neurological
+345.1	Epilepsy	neurological
+345.11	Generalized convulsive epilepsy	neurological
+345.12	Partial epilepsy	neurological
+345.3	Convulsions	neurological
+346	Abnormal findings on study of brain and/or nervous system	neurological
+346.1	Nonspecific abnormal findings on radiological and other examination of skull and head	neurological
+346.2	Nonspecific abnormal results of function study of brain and central nervous system	neurological
+346.3	Nonspecific abnormal findings in cerebrospinal fluid	neurological
+347	Cataplexy and narcolepsy	neurological
+348	Other conditions of brain	neurological
+348.2	Cerebral edema and compression of brain	neurological
+348.4	Cerebral cysts	neurological
+348.7	Coma	neurological
+348.8	"Encephalopathy, not elsewhere classified"	neurological
+348.9	"Other conditions of brain, NOS"	neurological
+349	Other and unspecified disorders of the nervous system	neurological
+350	Abnormal movement	neurological
+350.1	Abnormal involuntary movements	neurological
+350.2	Abnormality of gait	neurological
+350.3	Lack of coordination	neurological
+350.5	Abnormal reflex	neurological
+350.6	Disturbances of sensation of smell and taste	neurological
+351	Other peripheral nerve disorders	neurological
+352	Disorders of other cranial nerves	neurological
+352.1	Trigeminal nerve disorders [CN5]	neurological
+352.2	Facial nerve disorders [CN7]	neurological
+353	Nerve root and plexus disorders	neurological
+353.1	Nerve plexus lesions	neurological
+353.2	Nerve root lesions	neurological
+355	Complex regional/central pain syndrome	neurological
+355.1	Chronic pain syndrome	neurological
+356	Hereditary and idiopathic peripheral neuropathy	neurological
+357	Inflammatory and toxic neuropathy	neurological
+358	Myoneural disorders	neurological
+358.1	Myasthenia gravis	neurological
+359	Muscular dystrophies and other myopathies	neurological
+359.1	Muscular dystrophies	neurological
+359.2	Myopathy	neurological
+360	Disorders of the globe	sense organs
+360.2	Progressive myopia	sense organs
+360.3	Hypotony of eye	sense organs
+361	Retinal detachments and defects	sense organs
+361.1	Retinal detachment with retinal defect	sense organs
+361.2	Retinoschisis and retinal cysts	sense organs
+362	Other retinal disorders	sense organs
+362.1	Retinopathy of prematurity	sense organs
+362.2	Degeneration of macula and posterior pole of retina	sense organs
+362.21	"Macular degeneration, dry"	sense organs
+362.22	"Macular degeneration, wet"	sense organs
+362.23	Cystoid macular degeneration of retina	sense organs
+362.26	Macular puckering of retina	sense organs
+362.27	Drusen (degenerative) of retina	sense organs
+362.29	Macular degeneration (senile) of retina NOS	sense organs
+362.3	Other nondiabetic retinopathy	sense organs
+362.31	Separation of retinal layers	sense organs
+362.4	Retinal vascular changes and abnomalities	sense organs
+362.5	Toxic maculopathy of retina	sense organs
+362.6	Peripheral retinal degenerations	sense organs
+362.7	Hereditary retinal dystrophies	sense organs
+362.8	Retinal hemorrhage/ischemia	sense organs
+362.9	Retinal edema	sense organs
+363	"Chorioretinal inflammations, scars, and other disorders of choroid"	sense organs
+363.3	Chorioretinal scars	sense organs
+363.4	Choroidal degenerations	sense organs
+364	Corneal opacity and other disorders of cornea	sense organs
+364.1	Corneal opacity	sense organs
+364.2	Corneal edema	sense organs
+364.4	Corneal degenerations	sense organs
+364.41	Keratoconus	sense organs
+364.5	Corneal dystrophy	sense organs
+364.51	Fuchs' dystrophy	sense organs
+364.9	Cornea replaced by transplant	sense organs
+365	Glaucoma	sense organs
+365.1	Open-angle glaucoma	sense organs
+365.11	Primary open angle glaucoma	sense organs
+365.2	Primary angle-closure glaucoma	sense organs
+365.5	Pseudoexfoliation glaucoma	sense organs
+366	Cataract	sense organs
+366.1	Nonsenile Cataract	sense organs
+366.2	Senile cataract	sense organs
+366.3	Traumatic cataract	sense organs
+367	Disorders of refraction and accommodation; blindness and low vision	sense organs
+367.1	Myopia	sense organs
+367.2	Astigmatism	sense organs
+367.4	Presbyopia	sense organs
+367.8	Hypermetropia	sense organs
+367.9	Blindness and low vision	sense organs
+368	Visual disturbances	sense organs
+368.1	Amblyopia	sense organs
+368.2	Diplopia and disorders of binocular vision	sense organs
+368.3	Anisometropia	sense organs
+368.4	Visual field defects	sense organs
+368.5	Color vision deficiencies	sense organs
+368.7	Disorders of accommodation	sense organs
+368.9	Subjective visual disturbances	sense organs
+368.91	Psychophysical visual disturbances	sense organs
+369	Infection of the eye	sense organs
+369.2	"Eye infection, viral"	sense organs
+369.5	"Conjunctivitis, infectious"	sense organs
+370	Keratitis	sense organs
+370.1	Corneal ulcer	sense organs
+370.2	Superficial keratitis	sense organs
+370.3	Keratoconjunctivitis	sense organs
+370.31	Keratoconjunctivitis sicca	sense organs
+371	Inflammation of the eye	sense organs
+371.1	"Uveitis, noninfectious or NOS"	sense organs
+371.2	"Conjunctivitis, noninfectious"	sense organs
+371.21	Allergic conjunctivitis	sense organs
+371.3	Inflammation of eyelids	sense organs
+371.33	Noninfectious dermatoses of eyelid	sense organs
+371.9	Chronic inflammatory disorders of orbit	sense organs
+372	Disorders of conjunctiva	sense organs
+374	Other disorders of eyelids	sense organs
+374.1	Ectropion or entropion	sense organs
+374.2	Lagophthalmos	sense organs
+374.3	Ptosis of eyelid	sense organs
+374.6	Dermatochalasis	sense organs
+375	Disorders of lacrimal system	sense organs
+375.1	Dry eyes	sense organs
+375.2	Epiphora	sense organs
+376	Disorders of the orbit	sense organs
+377	Disorders of optic nerve and visual pathways	sense organs
+377.1	Optic atrophy	sense organs
+377.3	Optic neuritis/neuropathy	sense organs
+378	Strabismus and other disorders of binocular eye movements	sense organs
+378.1	Strabismus (not specified as paralytic)	sense organs
+378.2	Nystagmus and other irregular eye movements	sense organs
+378.5	Paralytic strabismus	sense organs
+379	Other disorders of eye	sense organs
+379.1	Scleritis and episcleritis	sense organs
+379.2	Disorders of vitreous body	sense organs
+379.3	Aphakia and other disorders of lens	sense organs
+379.4	Anomalies of pupillary function	sense organs
+379.5	Disorders of iris and ciliary body	sense organs
+379.51	Pigmentary iris degeneration	sense organs
+379.9	"Pain, swelling or discharge of eye"	sense organs
+380	Disorders of external ear	sense organs
+380.1	Otitis externa	sense organs
+380.4	Impacted cerumen	sense organs
+381	Otitis media and Eustachian tube disorders	sense organs
+381.1	Otitis media	sense organs
+381.11	Suppurative and unspecified otitis media	sense organs
+381.2	Eustachian tube disorders	sense organs
+381.3	Mastoiditis & related conditions	sense organs
+381.9	Otorrhea	sense organs
+382	Otalgia	sense organs
+383	Otosclerosis	sense organs
+384	Other disorders of tympanic membrane	sense organs
+384.1	Myringitis	sense organs
+384.4	Perforation of tympanic membrane	sense organs
+385	Other disorders of middle ear and mastoid	sense organs
+385.3	Cholesteatoma	sense organs
+385.5	Tympanosclerosis and middle ear disease related to otitis media	sense organs
+386	Vertiginous syndromes and other disorders of vestibular system	sense organs
+386.1	Meniere's disease	sense organs
+386.2	Peripheral or central vertigo	sense organs
+386.21	Central origin vertigo	sense organs
+386.3	Labyrinthitis	sense organs
+386.9	Dizziness and giddiness (Light-headedness and vertigo)	sense organs
+388	Other disorders of ear	sense organs
+389	Hearing loss	sense organs
+389.1	Sensorineural hearing loss	sense organs
+389.2	Conductive hearing loss	sense organs
+389.3	Degenerative and vascular disorders of ear	sense organs
+389.4	Tinnitus	sense organs
+389.5	Disorders of acoustic nerve	sense organs
+394	Rheumatic disease of the heart valves	circulatory system
+394.1	Mitral valve stenosis and aortic valve stenosis	circulatory system
+394.2	Mitral valve disease	circulatory system
+394.3	Aortic valve disease	circulatory system
+394.4	Acute rheumatic heart disease	circulatory system
+394.7	Disease of tricuspid valve	circulatory system
+395	Heart valve disorders	circulatory system
+395.1	Nonrheumatic mitral valve disorders	circulatory system
+395.2	Nonrheumatic aortic valve disorders	circulatory system
+395.3	Nonrheumatic tricuspid valve disorders	circulatory system
+395.4	Nonrheumatic pulmonary valve disorders	circulatory system
+395.6	Heart valve replaced	circulatory system
+396	Abnormal heart sounds	circulatory system
+401	Hypertension	circulatory system
+401.1	Essential hypertension	circulatory system
+401.2	Hypertensive heart and/or renal disease	circulatory system
+401.21	Hypertensive heart disease	circulatory system
+401.22	Hypertensive chronic kidney disease	circulatory system
+401.3	Other hypertensive complications	circulatory system
+402	Elevated blood pressure reading without diagnosis of hypertension	circulatory system
+411	Ischemic Heart Disease	circulatory system
+411.1	Unstable angina (intermediate coronary syndrome)	circulatory system
+411.2	Myocardial infarction	circulatory system
+411.3	Angina pectoris	circulatory system
+411.4	Coronary atherosclerosis	circulatory system
+411.41	Aneurysm and dissection of heart	circulatory system
+411.8	"Other chronic ischemic heart disease, unspecified"	circulatory system
+411.9	Other acute and subacute forms of ischemic heart disease	circulatory system
+414	Other forms of chronic heart disease	circulatory system
+414.2	ASCVD	circulatory system
+415	Pulmonary heart disease	circulatory system
+415.1	Acute pulmonary heart disease	circulatory system
+415.11	"Pulmonary embolism and infarction, acute"	circulatory system
+415.2	Chronic pulmonary heart disease	circulatory system
+415.21	Primary pulmonary hypertension	circulatory system
+416	Cardiomegaly	circulatory system
+418	Nonspecific chest pain	circulatory system
+418.1	Precordial pain	circulatory system
+420	Carditis	circulatory system
+420.1	Myocarditis	circulatory system
+420.2	Pericarditis	circulatory system
+420.21	Acute pericarditis	circulatory system
+420.22	Chronic pericarditis	circulatory system
+420.3	Endocarditis	circulatory system
+425	Cardiomyopathy	circulatory system
+425.1	Primary/intrinsic cardiomyopathies	circulatory system
+425.11	Hypertrophic obstructive cardiomyopathy	circulatory system
+425.12	Other hypertrophic cardiomyopathy	circulatory system
+425.2	Secondary/extrinsic cardiomyopathies	circulatory system
+425.8	Other cardiomyopathy	circulatory system
+426	Cardiac conduction disorders	circulatory system
+426.2	Atrioventricular [AV] block	circulatory system
+426.21	First degree AV block	circulatory system
+426.22	Mobitz II AV block	circulatory system
+426.23	Second degree AV block	circulatory system
+426.24	"Atrioventricular block, complete"	circulatory system
+426.25	Other heart block	circulatory system
+426.3	Bundle branch block	circulatory system
+426.31	Right bundle branch block	circulatory system
+426.32	Left bundle branch block	circulatory system
+426.4	Anomalous atrioventricular excitation	circulatory system
+426.7	Abnormal electrocardiogram [ECG] [EKG]	circulatory system
+426.8	Other cardiac conduction disorders	circulatory system
+426.9	Cardiac pacemaker/device in situ	circulatory system
+426.91	Cardiac pacemaker in situ	circulatory system
+426.92	Cardiac defibrillator in situ	circulatory system
+427	Cardiac dysrhythmias	circulatory system
+427.1	"Paroxysmal tachycardia, unspecified"	circulatory system
+427.11	Paroxysmal supraventricular tachycardia	circulatory system
+427.12	Paroxysmal ventricular tachycardia	circulatory system
+427.2	Atrial fibrillation and flutter	circulatory system
+427.21	Atrial fibrillation	circulatory system
+427.22	Atrial flutter	circulatory system
+427.3	Other specified cardiac dysrhythmias	circulatory system
+427.4	Cardiac arrest and ventricular fibrillation	circulatory system
+427.41	Ventricular fibrillation and flutter	circulatory system
+427.42	Cardiac arrest	circulatory system
+427.5	Arrhythmia (cardiac) NOS	circulatory system
+427.6	Premature beats	circulatory system
+427.61	Supraventricular premature beats	circulatory system
+427.7	Tachycardia NOS	circulatory system
+427.8	Sinoatrial node dysfunction (Bradycardia)	circulatory system
+427.9	Palpitations	circulatory system
+428	Congestive heart failure; nonhypertensive	circulatory system
+428.1	Congestive heart failure (CHF) NOS	circulatory system
+428.2	Heart failure NOS	circulatory system
+428.3	Heart failure with reduced EF [Systolic or combined heart failure]	circulatory system
+428.4	Heart failure with preserved EF [Diastolic heart failure]	circulatory system
+429	Ill-defined descriptions and complications of heart disease	circulatory system
+429.1	Heart transplant/surgery	circulatory system
+429.2	Abnormal function study of cardiovascular system	circulatory system
+429.3	Symptoms involving cardiovascular system	circulatory system
+429.9	"Cardiac complications, not elsewhere classified"	circulatory system
+430	Intracranial hemorrhage	circulatory system
+430.1	Subarachnoid hemorrhage	circulatory system
+430.2	Intracerebral hemorrhage	circulatory system
+430.3	Subdural hemorrhage	circulatory system
+433	Cerebrovascular disease	circulatory system
+433.1	Occlusion and stenosis of precerebral arteries	circulatory system
+433.11	"Occlusion of cerebral arteries, with cerebral infarction"	circulatory system
+433.12	Cerebral atherosclerosis	circulatory system
+433.2	Occlusion of cerebral arteries	circulatory system
+433.21	"Cerebral artery occlusion, with cerebral infarction"	circulatory system
+433.3	Cerebral ischemia	circulatory system
+433.31	Transient cerebral ischemia	circulatory system
+433.32	Moyamoya disease	circulatory system
+433.5	Cerebral aneurysm	circulatory system
+433.6	"Acute, but ill-defined cerebrovascular disease"	circulatory system
+433.8	Late effects of cerebrovascular disease	circulatory system
+440	Atherosclerosis	circulatory system
+440.1	Atherosclerosis of renal artery	circulatory system
+440.2	Atherosclerosis of the extremities	circulatory system
+440.21	Atherosclerosis of native arteries of the extremities with ulceration or gangrene	circulatory system
+440.22	Atherosclerosis of native arteries of the extremities with intermittent claudication	circulatory system
+440.9	Atherosclerosis of aorta	circulatory system
+441	Vascular insufficiency of intestine	circulatory system
+441.1	Acute vascular insufficiency of intestine	circulatory system
+441.2	Chronic vascular insufficiency of intestine	circulatory system
+442	Other aneurysm	circulatory system
+442.1	Aortic aneurysm	circulatory system
+442.11	Abdominal aortic aneurysm	circulatory system
+442.2	Aneurysm of iliac artery	circulatory system
+442.3	Aneurysm of artery of lower extremity	circulatory system
+442.4	Arterial dissection	circulatory system
+442.8	Aneurysm of other specified artery	circulatory system
+443	Peripheral vascular disease	circulatory system
+443.1	Raynaud's syndrome	circulatory system
+443.7	Peripheral angiopathy in diseases classified elsewhere	circulatory system
+443.8	Other specified peripheral vascular diseases	circulatory system
+443.9	"Peripheral vascular disease, unspecified"	circulatory system
+444	Arterial embolism and thrombosis	circulatory system
+444.1	Arterial embolism and thrombosis of lower extremity artery	circulatory system
+444.2	Embolism and thrombosis of abdominal aorta	circulatory system
+444.5	Atheroembolism	circulatory system
+446	Polyarteritis nodosa and allied conditions	circulatory system
+446.1	Thromboangiitis obliterans	circulatory system
+446.2	Acute febrile mucocutaneous lymph node syndrome (Kawasaki disease)	circulatory system
+446.3	Hypersensitivity angiitis	circulatory system
+446.4	Wegener's granulomatosis	circulatory system
+446.5	Giant cell arteritis	circulatory system
+446.6	Polyarteritis nodosa	circulatory system
+446.7	Takayasu's disease	circulatory system
+446.8	Thrombotic microangiopathy	circulatory system
+446.9	Arteritis NOS	circulatory system
+447	Other disorders of arteries and arterioles	circulatory system
+447.1	Stricture of artery	circulatory system
+447.7	Aortic ectasia	circulatory system
+448	Disease of capillaries	circulatory system
+450	Noninfectious disorders of lymphatic channels	circulatory system
+451	Phlebitis and thrombophlebitis	circulatory system
+451.2	Phlebitis and thrombophlebitis of lower extremities	circulatory system
+452	Other venous embolism and thrombosis	circulatory system
+452.1	Iatrogenic pulmonary embolism and infarction	circulatory system
+452.2	Deep vein thrombosis [DVT]	circulatory system
+452.8	Postphlebitic syndrome	circulatory system
+453	Chronic venous hypertension	circulatory system
+454	Varicose veins	circulatory system
+454.1	Varicose veins of lower extremity	circulatory system
+454.11	"Varicose veins of lower extremity, symptomtic"	circulatory system
+455	Hemorrhoids	circulatory system
+456	Chronic venous insufficiency [CVI]	circulatory system
+457	"Encounter for long-term (current) use of anticoagulants, antithrombotics, aspirin"	circulatory system
+457.2	Encounter for long-term (current) use of antiplatelets/antithrombotics	circulatory system
+457.3	Encounter for long-term (current) use of aspirin	circulatory system
+458	Hypotension	circulatory system
+458.1	Orthostatic hypotension	circulatory system
+458.2	Iatrogenic hypotension	circulatory system
+458.9	Hypotension NOS	circulatory system
+459	Other disorders of circulatory system	circulatory system
+459.1	Hemorrhage NOS	circulatory system
+459.7	Blood vessel replaced	circulatory system
+459.9	Circulatory disease NEC	circulatory system
+464	Acute sinusitis	respiratory
+465	Acute upper respiratory infections of multiple or unspecified sites	respiratory
+465.2	Acute pharyngitis	respiratory
+465.4	Acute laryngitis and tracheitis	respiratory
+470	Septal Deviations/Turbinate Hypertrophy	respiratory
+471	Nasal polyps	respiratory
+472	Chronic pharyngitis and nasopharyngitis	respiratory
+473	Diseases of the larynx and vocal cords	respiratory
+473.1	Chronic laryngitis	respiratory
+473.3	Paralysis/spasm of vocal cords or larynx	respiratory
+473.4	Voice disturbance	respiratory
+474	Acute and chronic tonsillitis	respiratory
+474.1	Acute tonsillitis	respiratory
+474.2	Chronic tonsillitis and adenoiditis	respiratory
+475	Chronic sinusitis	respiratory
+475.9	Postnasal drip	respiratory
+476	Allergic rhinitis	respiratory
+477	Epistaxis or throat hemorrhage	respiratory
+478	Throat pain	respiratory
+479	Other upper respiratory disease	respiratory
+480	Pneumonia	respiratory
+480.1	Bacterial pneumonia	respiratory
+480.11	Pneumococcal pneumonia	respiratory
+480.12	Pseudomonal pneumonia	respiratory
+480.13	MRSA pneumonia	respiratory
+480.2	Viral pneumonia	respiratory
+480.3	Pneumonia due to fungus (mycoses)	respiratory
+480.5	Bronchopneumonia and lung abscess	respiratory
+481	Influenza	respiratory
+483	Acute bronchitis and bronchiolitis	respiratory
+495	Asthma	respiratory
+495.1	Chronic obstructive asthma	respiratory
+495.11	Chronic obstructive asthma with exacerbation	respiratory
+495.2	Asthma with exacerbation	respiratory
+496	Chronic airway obstruction	respiratory
+496.1	Emphysema	respiratory
+496.2	Chronic bronchitis	respiratory
+496.21	Obstructive chronic bronchitis	respiratory
+496.3	Bronchiectasis	respiratory
+497	Bronchitis	respiratory
+498	Acute bronchospasm	respiratory
+499	Cystic fibrosis	respiratory
+500	Lung disease due to external agents	respiratory
+500.1	Extrinsic allergic alveolitis	respiratory
+500.2	Pneumoconiosis	respiratory
+501	Pneumonitis due to inhalation of food or vomitus	respiratory
+502	Postinflammatory pulmonary fibrosis	respiratory
+503	Pulmonary congestion and hypostasis	respiratory
+504	Other alveolar and parietoalveolar pneumonopathy	respiratory
+504.1	Idiopathic fibrosing alveolitis	respiratory
+505	Other pulmonary inflamation or edema	respiratory
+506	Empyema and pneumothorax	respiratory
+507	Pleurisy; pleural effusion	respiratory
+508	Pulmonary collapse; interstitial and compensatory emphysema	respiratory
+509	"Respiratory failure, insufficiency, arrest"	respiratory
+509.1	Respiratory failure	respiratory
+509.2	Respiratory insufficiency	respiratory
+509.3	Pulmonary insufficiency or respiratory failure following trauma and surgery	respiratory
+509.5	Respiratory arrest	respiratory
+509.8	Dependence on respirator [Ventilator] or supplemental oxygen	respiratory
+510	Other diseases of lung	respiratory
+510.2	Lung transplant	respiratory
+512	Other symptoms of respiratory system	respiratory
+512.1	Wheezing	respiratory
+512.2	Painful respiration	respiratory
+512.3	Abnormal chest sounds	respiratory
+512.7	Shortness of breath	respiratory
+512.8	Cough	respiratory
+512.9	Other dyspnea	respiratory
+513	Respiratory abnormalities	respiratory
+513.3	Hypoventilation	respiratory
+513.31	Apnea	respiratory
+513.32	Orthopnea	respiratory
+513.4	Hyperventilation	respiratory
+513.8	Disorders of diaphragm	respiratory
+514	Abnormal findings examination of lungs	respiratory
+514.1	Abnormal results of function study of pulmonary system	respiratory
+514.2	Solitary pulmonary nodule	respiratory
+516	Abnormal sputum	respiratory
+516.1	Hemoptysis	respiratory
+519	"Other diseases of respiratory system, not elsewhere classified"	respiratory
+519.1	Tracheostomy complications	respiratory
+519.2	Respiratory complications	respiratory
+519.8	"Other diseases of respiratory system, NEC"	respiratory
+519.9	Symptoms involving respiratory system and other chest symptoms	respiratory
+520	Disorders of tooth development	digestive
+520.1	Hereditary disturbances in tooth structure	digestive
+520.2	Disturbances in tooth eruption	digestive
+521	Diseases of hard tissues of teeth	digestive
+521.1	Dental caries	digestive
+521.2	"Dental abrasion, erosion and attrition"	digestive
+521.4	Tooth complications likely association with other diseases	digestive
+522	Diseases of pulp and periapical tissues	digestive
+522.1	Pulpitis and necrosis of tooth pulp	digestive
+522.5	Periapical abscess	digestive
+523	Gingival and periodontal diseases	digestive
+523.1	Gingivitis	digestive
+523.3	Periodontitis (acute or chronic)	digestive
+523.31	Acute periodontitis	digestive
+523.32	Chronic periodontitis	digestive
+524	"Dentofacial anomalies, including malocclusion"	digestive
+524.3	Anomalies of tooth position/malocclusion	digestive
+525	Other diseases of the teeth and supporting structures	digestive
+525.1	Loss of teeth or edentulism	digestive
+525.2	Atrophy of edentulous alveolar ridge	digestive
+526	Diseases of the jaws	digestive
+526.1	Cysts of the jaws	digestive
+526.3	Anomalies of jaw size/symmetry	digestive
+526.4	Temporomandibular joint disorders	digestive
+526.41	"Temporomandibular joint disorder, unspecified"	digestive
+526.42	Arthralgia/ankylosis of temporomandibular joint	digestive
+526.5	Inflammatory conditions of jaw	digestive
+526.8	Exostosis of jaw	digestive
+526.9	Jaw disease NOS	digestive
+527	Diseases of the salivary glands	digestive
+527.1	Hypertrophy of salivary gland	digestive
+527.2	Sialoadenitis	digestive
+527.7	Disturbance of salivary secretion	digestive
+527.8	Other specified diseases of the salivary glands	digestive
+528	"Diseases of the oral soft tissues, excluding lesions specific for gingiva and tongue"	digestive
+528.1	Stomatitis and mucositis	digestive
+528.11	Stomatitis and mucositis (ulcerative)	digestive
+528.12	Oral aphthae	digestive
+528.3	Cellulitis and abscess of oral soft tissues	digestive
+528.4	Cysts of oral soft tissues	digestive
+528.41	Cyst of the salivary gland	digestive
+528.5	Diseases of lips	digestive
+528.6	Leukoplakia of oral mucosa	digestive
+528.7	Sialolithiasis	digestive
+529	Diseases and other conditions of the tongue	digestive
+529.1	Glossitis	digestive
+529.6	Glossodynia	digestive
+530	Diseases of esophagus	digestive
+530.1	"Esophagitis, GERD and related diseases"	digestive
+530.11	GERD	digestive
+530.12	Ulcer of esophagus	digestive
+530.13	Barrett's esophagus	digestive
+530.14	Reflux esophagitis	digestive
+530.15	Eosinophilic esophagitis	digestive
+530.2	Esophageal bleeding (varices/hemorrhage)	digestive
+530.3	Stricture and stenosis of esophagus	digestive
+530.5	Disorders of esophageal motility	digestive
+530.6	"Diverticulum of esophagus, acquired"	digestive
+530.7	Gastroesophageal laceration-hemorrhage syndrome	digestive
+530.9	Heartburn	digestive
+531	Peptic ulcer (excl. esophageal)	digestive
+531.1	Hemorrhage from gastrointestinal ulcer	digestive
+531.2	Gastric ulcer	digestive
+531.3	Duodenal ulcer	digestive
+531.4	"Peptic ulcer, site unspecified"	digestive
+531.5	Gastrojejunal ulcer	digestive
+532	Dysphagia	digestive
+535	Gastritis and duodenitis	digestive
+535.1	Acute gastritis	digestive
+535.2	Atrophic gastritis	digestive
+535.6	Duodenitis	digestive
+535.8	Other specified gastritis	digestive
+535.9	"Gastritis and duodenitis, NOS"	digestive
+536	Disorders of function of stomach	digestive
+536.3	Gastroparesis	digestive
+536.7	"Complications of gastrostomy, colostomy and enterostomy"	digestive
+536.8	Dyspepsia and other specified disorders of function of stomach	digestive
+537	Other disorders of stomach and duodenum	digestive
+537.1	Lesions of stomach and duodenum	digestive
+539	Bariatric surgery	digestive
+540	Appendiceal conditions	digestive
+540.1	Appendicitis	digestive
+540.11	Acute appendicitis	digestive
+550	Abdominal hernia	digestive
+550.1	Inguinal hernia	digestive
+550.2	Diaphragmatic hernia	digestive
+550.3	Femoral hernia	digestive
+550.4	Umbilical hernia	digestive
+550.5	Ventral hernia	digestive
+550.6	Incisional hernia	digestive
+555	Inflammatory bowel disease and other gastroenteritis and colitis	digestive
+555.1	Regional enteritis	digestive
+555.2	Ulcerative colitis	digestive
+555.21	Ulcerative colitis (chronic)	digestive
+556	Ulceration of the lower GI tract	digestive
+556.1	Ulceration of intestine	digestive
+556.11	Angiodysplasia of intestine (without mention of hemorrhage)	digestive
+557	Intestinal malabsorption (non-celiac)	digestive
+557.1	Celiac disease	digestive
+558	Noninfectious gastroenteritis	digestive
+559	Ileostomy status	digestive
+560	Intestinal obstruction without mention of hernia	digestive
+560.1	Paralytic ileus	digestive
+560.2	Impaction of intestine	digestive
+560.3	Peritoneal or intestinal adhesions	digestive
+560.4	Other intestinal obstruction	digestive
+561	Symptoms involving digestive system	digestive
+561.1	Diarrhea	digestive
+561.2	Flatulence	digestive
+562	Diverticulosis and diverticulitis	digestive
+562.1	Diverticulosis	digestive
+562.2	Diverticulitis	digestive
+563	Constipation	digestive
+564	Functional digestive disorders	digestive
+564.1	Irritable Bowel Syndrome	digestive
+564.8	Abnormal findings on exam of gastrointestinal tract/ abdominal area	digestive
+564.9	Personal history of diseases of digestive system	digestive
+565	Anal and rectal conditions	digestive
+565.1	Anal and rectal polyp	digestive
+567	Peritonitis and retroperitoneal infections	digestive
+568	Other disorders of peritoneum	digestive
+568.1	Peritoneal adhesions (postoperative) (postinfection)	digestive
+569	Other disorders of intestine	digestive
+569.1	Toxic gastroenteritis and colitis	digestive
+569.2	Gastrointestinal complications	digestive
+571	Chronic liver disease and cirrhosis	digestive
+571.5	Other chronic nonalcoholic liver disease	digestive
+571.51	Cirrhosis of liver without mention of alcohol	digestive
+571.6	Primary biliary cirrhosis	digestive
+571.8	Liver abscess and sequelae of chronic liver disease	digestive
+571.81	Portal hypertension	digestive
+572	Ascites (non malignant)	digestive
+573	Other disorders of liver	digestive
+573.1	Chronic passive congestion of liver	digestive
+573.2	Liver replaced by transplant	digestive
+573.3	Hepatomegaly	digestive
+573.4	Acute and subacute necrosis of liver	digestive
+573.5	Jaundice (not of newborn)	digestive
+573.6	Nonspecific elevation of levels of transaminase or lactic acid dehydrogenase [LDH]	digestive
+573.7	Abnormal results of function study of liver	digestive
+573.9	Abnormal serum enzyme levels	digestive
+574	Cholelithiasis and cholecystitis	digestive
+574.1	Cholelithiasis	digestive
+574.11	Cholelithiasis with acute cholecystitis	digestive
+574.12	Cholelithiasis with other cholecystitis	digestive
+574.2	Calculus of bile duct	digestive
+574.3	Cholecystitis without cholelithiasis	digestive
+575	Other biliary tract disease	digestive
+575.1	Cholangitis	digestive
+575.2	Obstruction of bile duct	digestive
+575.6	Cholesterolosis of gallbladder	digestive
+575.7	Other disorders of gallbladder	digestive
+575.8	Other disorders of biliary tract	digestive
+575.9	Nonspecific abnormal findings on radiological and other examination of biliary tract	digestive
+577	Diseases of pancreas	digestive
+577.1	Acute pancreatitis	digestive
+577.2	Chronic pancreatitis	digestive
+577.3	Cyst and pseudocyst of pancreas	digestive
+578	Gastrointestinal hemorrhage	digestive
+578.1	Hematemesis	digestive
+578.2	Blood in stool	digestive
+578.8	Hemorrhage of rectum and anus	digestive
+578.9	Hemorrhage of gastrointestinal tract	digestive
+579	Other symptoms involving abdomen and pelvis	digestive
+579.2	Splenomegaly	digestive
+579.8	Nonspecific abnormal findings in stool contents	digestive
+580	Nephritis; nephrosis; renal sclerosis	genitourinary
+580.1	Glomerulonephritis	genitourinary
+580.11	Proliferative glomerulonephritis	genitourinary
+580.12	Non-proliferative glomerulonephritis	genitourinary
+580.13	"Acute glomerulonephritis, NOS"	genitourinary
+580.14	"Chronic glomerulonephritis, NOS"	genitourinary
+580.2	Nephrotic syndrome without mention of glomerulonephritis	genitourinary
+580.3	Nephritis and nephropathy without mention of glomerulonephritis	genitourinary
+580.31	Nephritis and nephropathy in diseases classified elsewhere	genitourinary
+580.32	Nephritis and nephropathy with pathological lesion	genitourinary
+580.4	"Renal sclerosis, NOS"	genitourinary
+585	Renal failure	genitourinary
+585.1	Acute renal failure	genitourinary
+585.2	Renal failure NOS	genitourinary
+585.3	Chronic renal failure [CKD]	genitourinary
+585.31	Renal dialysis	genitourinary
+585.32	End stage renal disease	genitourinary
+585.33	"Chronic Kidney Disease, Stage III"	genitourinary
+585.34	"Chronic Kidney Disease, Stage IV"	genitourinary
+585.4	"Chronic kidney disease, Stage I or II"	genitourinary
+586	Other disorders of the kidney and ureters	genitourinary
+586.1	Anatomical abnormatilies of kidney and ureters	genitourinary
+586.11	Small kidney	genitourinary
+586.12	Vesicoureteral reflux	genitourinary
+586.2	"Cyst of kidney, acquired"	genitourinary
+586.3	Vascular disorders of kidney/hypertrophy	genitourinary
+586.4	Stricture/obstruction of ureter	genitourinary
+587	Kidney replaced by transpant	genitourinary
+588	Disorders resulting from impaired renal function	genitourinary
+588.1	Renal osteodystrophy	genitourinary
+588.2	Secondary hyperparathyroidism (of renal origin)	genitourinary
+589	Abnormal results of function study of kidney	genitourinary
+590	Pyelonephritis	genitourinary
+591	Urinary tract infection	genitourinary
+592	Cystitis and urethritis	genitourinary
+592.1	Cystitis	genitourinary
+592.11	Acute cystitis	genitourinary
+592.12	Chronic cystitis	genitourinary
+592.13	Chronic interstitial cystitis	genitourinary
+592.2	Urethritis and urethral syndrome	genitourinary
+592.21	Urethral syndrome	genitourinary
+592.3	Urethral stricture due to infecton	genitourinary
+593	Hematuria	genitourinary
+593.1	Gross hematuria	genitourinary
+593.2	Microscopic hematuria	genitourinary
+594	Urinary calculus	genitourinary
+594.1	Calculus of kidney	genitourinary
+594.2	Calculus of lower urinary tract	genitourinary
+594.3	Calculus of ureter	genitourinary
+594.8	Renal colic	genitourinary
+595	Hydronephrosis	genitourinary
+596	Other disorders of bladder	genitourinary
+596.1	Bladder neck obstruction	genitourinary
+596.5	Functional disorders of bladder	genitourinary
+597	Other disorders of urethra and urinary tract	genitourinary
+597.1	Urethral stricture (not specified as infectious)	genitourinary
+597.2	Urinary complications NEC	genitourinary
+597.8	Urethral hypermobility/ISD	genitourinary
+598	Abnormal findings on examination of urine	genitourinary
+598.4	Other cells and casts in urine	genitourinary
+598.9	Other nonspecific findings on examination of urine	genitourinary
+599	Other symptoms/disorders or the urinary system	genitourinary
+599.1	Urinary obstruction	genitourinary
+599.2	Retention of urine	genitourinary
+599.3	Dysuria	genitourinary
+599.4	Urinary incontinence	genitourinary
+599.5	Frequency of urination and polyuria	genitourinary
+599.6	Oliguria and anuria	genitourinary
+599.7	Urethral discharge	genitourinary
+599.8	Other symptoms involving urinary system	genitourinary
+599.9	Other abnormality of urination	genitourinary
+600	Hyperplasia of prostate	genitourinary
+601	Inflammatory diseases of prostate	genitourinary
+601.1	Prostatitis	genitourinary
+601.11	Acute prostatitis	genitourinary
+601.12	Chronic prostatitis	genitourinary
+601.3	Orchitis and epididymitis	genitourinary
+601.4	Balanoposthitis	genitourinary
+601.8	Other inflammatory disorders of male genital organs	genitourinary
+602	Other disorders of prostate	genitourinary
+602.3	Dysplasia of prostate	genitourinary
+603	Other disorders of testis	genitourinary
+603.1	Hydrocele	genitourinary
+603.2	Spermatocele	genitourinary
+604	Disorders of penis	genitourinary
+604.1	Redundant prepuce and phimosis/BXO	genitourinary
+604.2	Vascular disorders of penis	genitourinary
+604.3	Peyronie's disease	genitourinary
+605	Erectile dysfunction [ED]	genitourinary
+608	Other disorders of male genital organs	genitourinary
+609	Male infertility and abnormal spermatozoa	genitourinary
+609.1	"Infertility, male"	genitourinary
+609.11	Azoospermia and oligospermia	genitourinary
+609.2	Abnormal spermatozoa	genitourinary
+610	Benign mammary dysplasias	genitourinary
+610.1	Cystic mastopathy	genitourinary
+610.2	Fibroadenosis of breast	genitourinary
+610.3	Fibrosclerosis of breast	genitourinary
+610.4	Benign neoplasm of breast	genitourinary
+610.8	Other specified benign mammary dysplasias	genitourinary
+611	Abnormal findings on mammogram or breast exam	genitourinary
+611.1	Abnormal mammogram	genitourinary
+611.11	Mammographic microcalcification	genitourinary
+611.3	Lump or mass in breast	genitourinary
+612	"Breast conditions, congenital or relating to hormones"	genitourinary
+612.1	Galactorrhea	genitourinary
+612.2	Hypertrophy of breast (Gynecomastia)	genitourinary
+612.3	Congenital anomalies of breast	genitourinary
+613	Other nonmalignant breast conditions	genitourinary
+613.1	Inflammatory disease of breast	genitourinary
+613.5	Mastodynia	genitourinary
+613.7	Other signs and symptoms in breast	genitourinary
+613.8	Other specified disorders of breast	genitourinary
+613.9	Breast disorder NOS	genitourinary
+614	Inflammatory diseases of female pelvic organs	genitourinary
+614.1	"Pelvic peritoneal adhesions, female (postoperative) (postinfection)"	genitourinary
+614.3	Pelvic inflammatory disease (PID)	genitourinary
+614.31	Acute inflammatory pelvic disease	genitourinary
+614.32	Chronic inflammatory pelvic disease	genitourinary
+614.33	"Pelvic inflammatory disease, NOS"	genitourinary
+614.4	"Inflammatory diseases of uterus, except cervix"	genitourinary
+614.5	"Inflammatory disease of cervix, vagina, and vulva"	genitourinary
+614.51	Cervicitis and endocervicitis	genitourinary
+614.52	Vaginitis and vulvovaginitis	genitourinary
+614.53	Cyst or abscess of Bartholin's gland	genitourinary
+614.54	Abscess or ulceration of vulva	genitourinary
+615	Endometriosis	genitourinary
+617	"Disorders secondary to childbirth, surgery, trauma"	genitourinary
+618	Genital prolapse	genitourinary
+618.1	Prolapse of vaginal walls	genitourinary
+618.2	Uterine/Uterovaginal prolapse	genitourinary
+618.5	Prolapse of vaginal vault after hysterectomy	genitourinary
+618.6	"Vaginal enterocele, congenital or acquired"	genitourinary
+619	Noninflammatory female genital disorders	genitourinary
+619.1	"Noninflammatory disorders of ovary, fallopian tube, and broad ligament"	genitourinary
+619.2	"Disorders of uterus, NEC"	genitourinary
+619.3	Noninflammatory disorders of cervix	genitourinary
+619.4	Noninflammatory disorders of vagina	genitourinary
+619.5	Noninflammatory disorders of vulva and perineum	genitourinary
+620	Dysplasia of female genital organs	genitourinary
+620.1	Dysplasia of cervix	genitourinary
+621	Endometrial hyperplasia	genitourinary
+622	Polyp of female genital organs	genitourinary
+622.1	Polyp of corpus uteri	genitourinary
+622.2	Mucous polyp of cervix	genitourinary
+623	Hypertrophy of female genital organs	genitourinary
+624	Symptoms involving female genital tract	genitourinary
+624.1	Dystrophy of female genital tract	genitourinary
+624.2	Atrophy of female genital tract	genitourinary
+624.9	"stress incontinence, female"	genitourinary
+625	Pain and other symptoms associated with female genital organs	genitourinary
+625.1	Dyspareunia	genitourinary
+626	Disorders of menstruation and other abnormal bleeding from female genital tract	genitourinary
+626.1	Irregular menstrual cycle/bleeding	genitourinary
+626.11	Absent or infrequent menstruation	genitourinary
+626.12	Excessive or frequent menstruation	genitourinary
+626.13	Irregular menstrual cycle	genitourinary
+626.14	Irregular menstrual bleeding	genitourinary
+626.15	"Infertility, female, associated with anovulation"	genitourinary
+626.2	Dysmenorrhea	genitourinary
+626.21	Mittelschmerz	genitourinary
+626.4	Premenstrual tension syndromes	genitourinary
+626.8	"Infertility, female"	genitourinary
+627	Menopausal and postmenopausal disorders	genitourinary
+627.1	Postmenopausal bleeding	genitourinary
+627.2	Symptomatic menopause	genitourinary
+627.21	Symptomatic artificial menopause	genitourinary
+627.22	Need for Hormone replacement therapy (postmenopausal)	genitourinary
+627.3	Postmenopausal atrophic vaginitis	genitourinary
+627.4	Premenopausal menorrhagia	genitourinary
+627.5	Premature menopause and other ovarian failure	genitourinary
+628	Ovarian cyst	genitourinary
+634	Miscarriage; stillbirth	pregnancy complications
+634.1	Missed abortion/Hydatidiform mole	pregnancy complications
+634.3	Ectopic pregnancy	pregnancy complications
+635	Hemorrhage during pregnancy; childbirth and postpartum	pregnancy complications
+635.2	"Antepartum hemorrhage, abruptio placentae, and placenta previa"	pregnancy complications
+635.3	Placenta previa and abruptio placenta	pregnancy complications
+636	Early or threatened labor; hemorrhage in early pregnancy	pregnancy complications
+636.1	Threatened premature labor	pregnancy complications
+636.2	Early onset of delivery	pregnancy complications
+636.3	Hemorrhage in early pregnancy	pregnancy complications
+636.8	Cervical incompetence	pregnancy complications
+637	Short gestation; low birth weight; and fetal growth retardation	pregnancy complications
+638	Other high-risk pregnancy	pregnancy complications
+639	Complications following abortion or ectopic and molar pregnancies	pregnancy complications
+642	"Hypertension complicating pregnancy, childbirth, and the puerperium"	pregnancy complications
+642.1	Preeclampsia and eclampsia	pregnancy complications
+643	Excessive vomiting in pregnancy	pregnancy complications
+643.1	Hyperemesis gravidarum	pregnancy complications
+644	Anemia during pregnancy	pregnancy complications
+645	Late pregnancy and failed induction	pregnancy complications
+646	Other complications of pregnancy NEC	pregnancy complications
+647	Infectious and parasitic complications affecting pregnancy	pregnancy complications
+647.1	Infections of genitourinary tract during pregnancy	pregnancy complications
+647.3	Major puerperal infection	pregnancy complications
+649	"Other conditions or status of the mother complicating pregnancy, childbirth, or the puerperium"	pregnancy complications
+649.1	Diabetes or abnormal glucose tolerance complicating pregnancy	pregnancy complications
+650	Normal delivery	pregnancy complications
+651	Multiple gestation	pregnancy complications
+652	Malposition and malpresentation of fetus or obstruction	pregnancy complications
+653	Problems associated with amniotic cavity and membranes	pregnancy complications
+654	Other and unspecified complications of birth; puerperium affecting management of mother	pregnancy complications
+654.1	"Abnormality of organs and soft tissues of pelvis complicating pregnancy, childbirth, or the puerperium"	pregnancy complications
+654.2	Rhesus isoimmunization in pregnancy	pregnancy complications
+655	Known or suspected fetal abnormality affecting management of mother	pregnancy complications
+655.1	Abnormality in fetal heart rate or rhythm	pregnancy complications
+656	Other perinatal conditions of fetus or newborn	pregnancy complications
+656.1	Isoimmunization of fetus or newborn	pregnancy complications
+656.2	Respiratory conditions of fetus and newborn	pregnancy complications
+656.22	Interstitial emphysema and related conditions of newborn	pregnancy complications
+656.26	Transitory tachypnea or apnea of newborn	pregnancy complications
+656.3	Endocrine and metabolic disturbances of fetus and newborn	pregnancy complications
+656.4	Hemorrhage of fetus or newborn	pregnancy complications
+656.5	Hematological disorders of newborn	pregnancy complications
+656.6	Perinatal disorders of digestive system	pregnancy complications
+656.7	Conditions involving the integument and temperature regulation of fetus and newborn	pregnancy complications
+656.8	Perinatal jaundice	pregnancy complications
+656.9	Neonatal bradycardia or tachycardia	pregnancy complications
+657	Infections specific to the perinatal period	pregnancy complications
+658	Maternal complication of pregnancy affecting fetus or newborn	pregnancy complications
+661	Fetal distress and abnormal forces of labor	pregnancy complications
+663	Umbilical cord complications during labor and delivery	pregnancy complications
+665	Obstetrical/birth trauma	pregnancy complications
+668	Complications of the administration of anesthetic or other sedation in labor and delivery	pregnancy complications
+669	Complications of labor and delivery NEC	pregnancy complications
+671	Venous/cerebrovascular complications embolism in pregnancy and the puerperium	pregnancy complications
+674	Other complications of the puerperium NEC	pregnancy complications
+676	Other disorders of the breast associated with childbirth and disorders of lactation	pregnancy complications
+679	Complications of in utero procedures	pregnancy complications
+681	Superficial cellulitis and abscess	dermatologic
+681.1	Cellulitis and abscess of fingers/toes	dermatologic
+681.2	Cellulitis and abscess of face/neck	dermatologic
+681.3	Cellulitis and abscess of arm/hand	dermatologic
+681.5	"Cellulitis and abscess of leg, except foot"	dermatologic
+681.6	"Cellulitis and abscess of foot, toe"	dermatologic
+681.7	Cellulitis and abscess of trunk	dermatologic
+686	Other local infections of skin and subcutaneous tissue	dermatologic
+686.1	Carbuncle and furuncle	dermatologic
+686.2	Impetigo	dermatologic
+686.3	Pilonidal cyst	dermatologic
+686.4	Pyogenic granuloma	dermatologic
+686.5	Pyoderma	dermatologic
+687	Symptoms affecting skin	dermatologic
+687.1	Rash and other nonspecific skin eruption	dermatologic
+687.2	"Localized superficial swelling, mass, or lump"	dermatologic
+687.3	Changes in skin texture	dermatologic
+687.4	Disturbance of skin sensation	dermatologic
+689	Disorder of skin and subcutaneous tissue NOS	dermatologic
+690	Erythematosquamous dermatosis	dermatologic
+690.1	Seborrheic dermatitis	dermatologic
+691	Congenital anomalies of skin	dermatologic
+691.1	Ichthyosis congenita	dermatologic
+691.3	Congenital pigmentary anomalies of skin	dermatologic
+694	Dyschromia and Vitiligo	dermatologic
+694.1	Vitiligo	dermatologic
+694.2	Other dyschromia	dermatologic
+694.3	Vascular disorders of skin	dermatologic
+695	Erythematous conditions	dermatologic
+695.1	Toxic erythema	dermatologic
+695.2	Bullous dermatoses	dermatologic
+695.21	Dermatitis herpetiformis	dermatologic
+695.22	Pemphigus and pemphigoid	dermatologic
+695.3	Rosacea	dermatologic
+695.4	Lupus (localized and systemic)	dermatologic
+695.41	Cutaneous lupus erythematosus	dermatologic
+695.42	Systemic lupus erythematosus	dermatologic
+695.7	Prurigo and Lichen	dermatologic
+695.8	Other specified erythematous conditions	dermatologic
+695.81	Erythema nodosum	dermatologic
+695.9	Unspecified erythematous condition	dermatologic
+696	Psoriasis and related disorders	dermatologic
+696.2	Parapsoriasis	dermatologic
+696.3	Pityriasis	dermatologic
+696.4	Psoriasis	dermatologic
+696.41	Psoriasis vulgaris	dermatologic
+696.42	Psoriatic arthropathy	dermatologic
+697	Sarcoidosis	dermatologic
+698	Pruritus and related conditions	dermatologic
+700	Corns and callosities	dermatologic
+701	Other hypertrophic and atrophic conditions of skin	dermatologic
+701.1	"Keratoderma, acquired"	dermatologic
+701.2	Scar conditions and fibrosis of skin	dermatologic
+701.3	Circumscribed scleroderma	dermatologic
+701.4	Keloid scar	dermatologic
+701.5	Abnormal granulation tissue	dermatologic
+701.6	Acquired acanthosis nigricans	dermatologic
+702	Degenerative skin conditions and other dermatoses	dermatologic
+702.1	Actinic keratosis	dermatologic
+702.2	Seborrheic keratosis	dermatologic
+702.4	Degenerative skin disorders	dermatologic
+703	"Diseases of nail, NOS"	dermatologic
+703.1	Ingrowing nail	dermatologic
+704	Diseases of hair and hair follicles	dermatologic
+704.1	Alopecia	dermatologic
+704.11	Alopecia Areata	dermatologic
+704.12	Telogen effluvium	dermatologic
+704.2	Hirsutism	dermatologic
+704.8	Other specified diseases of hair and hair follicles	dermatologic
+705	Disorders of sweat glands	dermatologic
+705.1	Dyshidrosis	dermatologic
+705.3	Hidradenitis	dermatologic
+705.8	Hyperhidrosis	dermatologic
+706	Diseases of sebaceous glands	dermatologic
+706.1	Acne	dermatologic
+706.2	Sebaceous cyst	dermatologic
+706.3	Seborrhea	dermatologic
+706.8	Other specified diseases of sebaceous glands	dermatologic
+707	Chronic ulcer of skin	dermatologic
+707.1	Decubitus ulcer	dermatologic
+707.2	Chronic ulcer of leg or foot	dermatologic
+707.3	Chronic ulcer of unspecified site	dermatologic
+709	Diffuse diseases of connective tissue	dermatologic
+709.2	Sicca syndrome	dermatologic
+709.3	Systemic sclerosis	dermatologic
+709.4	Polymyositis	dermatologic
+709.5	Dermatomyositis	dermatologic
+709.6	Other specified diffuse diseases of connective tissue	dermatologic
+709.7	Unspecified diffuse connective tissue disease	dermatologic
+710	"Osteomyelitis, periostitis, and other infections involving bone"	musculoskeletal
+710.1	Osteomyelitis	musculoskeletal
+710.11	Acute osteomyelitis	musculoskeletal
+710.12	Chronic osteomyelitis	musculoskeletal
+710.19	Unspecified osteomyelitis	musculoskeletal
+710.2	Periostitis	musculoskeletal
+710.3	Osteopathy resulting from poliomyelitis	musculoskeletal
+711	Arthropathy associated with infections	musculoskeletal
+711.1	Pyogenic arthritis	musculoskeletal
+711.2	Reiter's disease	musculoskeletal
+711.3	Behcet's syndrome	musculoskeletal
+712	Infective connective tissue disorders	musculoskeletal
+713	Arthropathy associated with other disorders classified elsewhere	musculoskeletal
+713.5	Arthropathy associated with neurological disorders	musculoskeletal
+714	Rheumatoid arthritis and other inflammatory polyarthropathies	musculoskeletal
+714.1	Rheumatoid arthritis	musculoskeletal
+714.2	Juvenile rheumatoid arthritis	musculoskeletal
+715	Other inflammatory spondylopathies	musculoskeletal
+715.1	Sacroiliitis NEC	musculoskeletal
+715.2	Ankylosing spondylitis	musculoskeletal
+715.3	Spinal enthesopathy	musculoskeletal
+716	Other arthropathies	musculoskeletal
+716.1	Unspecified polyarthropathy or polyarthritis	musculoskeletal
+716.2	Unspecified monoarthritis	musculoskeletal
+716.3	Kaschin-Beck disease	musculoskeletal
+716.8	Palindromic rheumatism	musculoskeletal
+716.9	Arthropathy NOS	musculoskeletal
+717	Polymyalgia Rheumatica	musculoskeletal
+720	Spinal stenosis	musculoskeletal
+720.1	Spinal stenosis of lumbar region	musculoskeletal
+721	Spondylosis and allied disorders	musculoskeletal
+721.1	Spondylosis without myelopathy	musculoskeletal
+721.2	Spondylosis with myelopathy	musculoskeletal
+721.8	Other allied disorders of spine	musculoskeletal
+722	Intervertebral disc disorders	musculoskeletal
+722.1	Displacement of intervertebral disc	musculoskeletal
+722.3	Schmorl's nodes	musculoskeletal
+722.6	Degeneration of intervertebral disc	musculoskeletal
+722.7	Intervertebral disc disorder with myelopathy	musculoskeletal
+722.8	Postlaminectomy syndrome	musculoskeletal
+722.9	Other and unspecified disc disorder	musculoskeletal
+723	Other disorders of cervical region	musculoskeletal
+723.1	Torticollis	musculoskeletal
+724	Other and unspecified disorders of back	musculoskeletal
+724.1	Disorders of sacrum	musculoskeletal
+724.2	Disorders of coccyx	musculoskeletal
+724.8	Other symptoms referable to back	musculoskeletal
+724.9	Other unspecified back disorders	musculoskeletal
+726	Peripheral enthesopathies and allied syndromes	musculoskeletal
+726.1	Enthesopathy	musculoskeletal
+726.2	Synoviopathy	musculoskeletal
+726.3	Bursitis	musculoskeletal
+726.4	Calcaneal spur; Exostosis NOS	musculoskeletal
+727	"Other disorders of synovium, tendon, and bursa"	musculoskeletal
+727.1	Synovitis and tenosynovitis	musculoskeletal
+727.2	Bursitis disorders	musculoskeletal
+727.4	"Ganglion and cyst of synovium, tendon, and bursa"	musculoskeletal
+727.5	Rupture of synovium	musculoskeletal
+727.6	"Rupture of tendon, nontraumatic"	musculoskeletal
+727.7	Contracture of tendon (sheath)	musculoskeletal
+727.8	Plica syndrome	musculoskeletal
+728	"Disorders of muscle, ligament, and fascia"	musculoskeletal
+728.1	Muscular calcification and ossification	musculoskeletal
+728.2	Laxity of ligament or hypermobility syndrome	musculoskeletal
+728.7	Fasciitis	musculoskeletal
+728.71	Contracture of palmar fascia [Dupuytren's disease]	musculoskeletal
+729	Other disorders of soft tissues	musculoskeletal
+729.1	"Rheumatism, unspecified and fibrositis"	musculoskeletal
+729.3	Panniculitis	musculoskeletal
+729.7	Nontraumatic compartment syndrome	musculoskeletal
+731	Osteitis deformans and osteopathies associated with other disorders classified elsewhere	musculoskeletal
+731.1	Osteitis deformans [Paget's disease of bone]	musculoskeletal
+732	Osteochondropathies	musculoskeletal
+732.1	Juvenile osteochondrosis	musculoskeletal
+732.7	Osteochondritis dissecans	musculoskeletal
+733	Other disorders of bone and cartilage	musculoskeletal
+733.2	Cyst of bone	musculoskeletal
+733.4	Aseptic necrosis of bone	musculoskeletal
+733.6	Costochondritis	musculoskeletal
+733.8	Malunion and nonunion of fracture	musculoskeletal
+733.9	Chondromalacia	musculoskeletal
+735	Acquired foot deformities	musculoskeletal
+735.1	Flat foot	musculoskeletal
+735.2	Acquired toe deformities	musculoskeletal
+735.21	Hammer toe (acquired)	musculoskeletal
+735.22	Claw toe (acquired)	musculoskeletal
+735.23	Hallux rigidus	musculoskeletal
+735.3	Hallux valgus (Bunion)	musculoskeletal
+736	Other acquired deformities of limbs	musculoskeletal
+736.1	Acquired deformities of forearm	musculoskeletal
+736.2	Acquired deformities of finger	musculoskeletal
+736.3	Acquired deformities of hip	musculoskeletal
+736.4	Genu valgum or varum (acquired)	musculoskeletal
+736.5	Acquired deformities of knee	musculoskeletal
+736.6	Unequal leg length (acquired)	musculoskeletal
+737	Curvature of spine	musculoskeletal
+737.1	Kyphosis (acquired)	musculoskeletal
+737.2	Lordosis (acquired)	musculoskeletal
+737.3	Kyphoscoliosis and scoliosis	musculoskeletal
+738	Other acquired musculoskeletal deformity	musculoskeletal
+738.4	Acquired spondylolisthesis	musculoskeletal
+739	Contracture of joint	musculoskeletal
+740	Osteoarthrosis	musculoskeletal
+740.1	Osteoarthritis; localized	musculoskeletal
+740.11	"Osteoarthrosis, localized, primary"	musculoskeletal
+740.12	"Osteoarthrosis, localized, secondary"	musculoskeletal
+740.2	"Osteoarthrosis, generalized"	musculoskeletal
+740.3	"Osteoarthrosis involving more than one site, but not specified as generalized"	musculoskeletal
+740.9	Osteoarthrosis NOS	musculoskeletal
+741	Symptoms and disorders of the joints	musculoskeletal
+741.1	Ankylosis of joint	musculoskeletal
+741.2	Stiffness of joint	musculoskeletal
+741.3	Difficulty in walking	musculoskeletal
+741.4	Joint effusions	musculoskeletal
+741.5	Hemarthrosis	musculoskeletal
+741.6	Villonodular synovitis	musculoskeletal
+742	"Derangement of joint, non-traumatic"	musculoskeletal
+742.1	Loose body in joint	musculoskeletal
+742.2	"Pathological, developmental or recurrent dislocation"	musculoskeletal
+742.8	Articular cartilage disorder	musculoskeletal
+742.9	Other derangement of joint	musculoskeletal
+743	"Osteoporosis, osteopenia and pathological fracture"	musculoskeletal
+743.1	Osteoporosis	musculoskeletal
+743.11	Osteoporosis NOS	musculoskeletal
+743.12	Senile osteoporosis	musculoskeletal
+743.13	Other specified osteoporosis	musculoskeletal
+743.2	Pathologic fracture	musculoskeletal
+743.21	Pathologic fracture of vertebrae	musculoskeletal
+743.22	Pathologic fracture of femur	musculoskeletal
+743.4	Stress fracture	musculoskeletal
+743.9	Osteopenia or other disorder of bone and cartilage	musculoskeletal
+745	Pain in joint	musculoskeletal
+747	Cardiac and circulatory congenital anomalies	congenital anomalies
+747.1	Cardiac congenital anomalies	congenital anomalies
+747.11	Cardiac shunt/ heart septal defect	congenital anomalies
+747.12	Valvular heart disease/ heart chambers	congenital anomalies
+747.13	Congenital anomalies of great vessels	congenital anomalies
+747.2	Congenital anomalies of peripheral vascular system	congenital anomalies
+748	"Anomalies of respiratory system, congenital"	congenital anomalies
+749	Congenital anomalies of face and neck	congenital anomalies
+749.1	Cleft palate	congenital anomalies
+749.2	Congenital anomalies of skull and face bones	congenital anomalies
+750	Digestive congenital anomalies	congenital anomalies
+750.1	Upper gastrointestinal congenital anomalies	congenital anomalies
+750.11	Esophageal atresia/tracheoesophageal fistula	congenital anomalies
+750.13	Congenital anomalies of mouth/tongue	congenital anomalies
+750.14	Congenital anomalies of esophagus	congenital anomalies
+750.15	Congenital anomalies of stomach	congenital anomalies
+750.2	Lower gastrointestinal congenital anomalies	congenital anomalies
+750.21	Congenital anomalies of intestine	congenital anomalies
+750.22	"Congenital anomaly of gallbladder, bile ducts, liver, pancreas"	congenital anomalies
+750.5	Congenital hypertrophic pyloric stenosis	congenital anomalies
+751	Genitourinary congenital anomalies	congenital anomalies
+751.1	Congenital anomalies of genital organs	congenital anomalies
+751.11	Congenital anomalies of female genital organs	congenital anomalies
+751.12	Congenital anomalies of male genital organs	congenital anomalies
+751.2	Congenital anomalies of urinary system	congenital anomalies
+751.21	Cystic kidney disease	congenital anomalies
+751.22	Other specified congenital anomalies of kidney	congenital anomalies
+751.3	Obstructive genitourinary defect	congenital anomalies
+752	Nervous system congenital anomalies	congenital anomalies
+752.1	Neural tube defects	congenital anomalies
+752.11	Spina bifida	congenital anomalies
+752.2	Other specified congenital anomalies of nervous system	congenital anomalies
+753	Congenital anomalies of the eye	congenital anomalies
+753.1	Congenital cataract and lens anomalies	congenital anomalies
+753.2	Congenital anomalies of posterior segment of eye	congenital anomalies
+754	Congenital musculoskeletal deformities of spine	congenital anomalies
+754.1	"Lumbosacral spondylolysis, congenital"	congenital anomalies
+754.2	"Spondylolisthesis, congenital"	congenital anomalies
+755	Congenital anomalies of limbs	congenital anomalies
+755.1	Congenital deformities of feet	congenital anomalies
+755.3	Congenital anomaly of fingers/toes	congenital anomalies
+755.4	"Congenital anomalies of upper limb, including shoulder girdle"	congenital anomalies
+755.6	"Other congenital anomalies of lower limb, including pelvic girdle"	congenital anomalies
+755.61	Congenital hip dysplasia and deformity	congenital anomalies
+756	Other congenital musculoskeletal anomalies	congenital anomalies
+756.1	Congenital anomalies of abdominal wall; diaphram	congenital anomalies
+756.2	Pectus and other congenital anomalies of ribs/sternum	congenital anomalies
+756.21	Pectus excavatum	congenital anomalies
+756.22	Pectus carinatum	congenital anomalies
+756.3	"Congenital anomalies of muscle, tendon, fascia, and connective tissue"	congenital anomalies
+756.5	Congenital osteodystrophies	congenital anomalies
+757	Congenital anomalies of the integument	congenital anomalies
+758	Chromosomal anomalies and genetic disorders	congenital anomalies
+758.1	Chromosomal anomalies	congenital anomalies
+759	Other and unspecified congenital anomalies	congenital anomalies
+759.1	"Anomalies of endocrine glands, congenital"	congenital anomalies
+760	Back pain	symptoms
+761	Cervicalgia	symptoms
+763	"Thoracic or lumbosacral neuritis or radiculitis, unspecified"	symptoms
+764	Sciatica	symptoms
+765	Cervical radiculitis	symptoms
+766	"Neuralgia, neuritis, and radiculitis NOS"	symptoms
+767	Cervicocranial/Cervicobrachial syndrome	symptoms
+769	Nonallopathic lesions NEC	symptoms
+770	Myalgia and myositis unspecified	symptoms
+771	Musculoskeletal symptoms referable to limbs	symptoms
+771.1	Swelling of limb	symptoms
+771.2	Cramp of limb	symptoms
+772	Symptoms of the muscles	symptoms
+772.1	Muscular wasting and disuse atrophy	symptoms
+772.2	Spasm of muscle	symptoms
+772.3	Muscle weakness	symptoms
+772.4	Rhabdomyolysis	symptoms
+772.6	Facial weakness	symptoms
+773	Pain in limb	symptoms
+780	Hypothermia/Chills	symptoms
+781	Symptoms involving nervous and musculoskeletal systems	symptoms
+781.1	Loss of height	symptoms
+781.2	Abnormal posture	symptoms
+782	Symptoms involving skin and other integumentary tissue	symptoms
+782.3	Edema	symptoms
+782.6	Pallor and flushing	symptoms
+783	Fever of unknown origin	symptoms
+783.1	Postprocedural fever	symptoms
+785	Abdominal pain	symptoms
+788	Syncope and collapse	symptoms
+789	Nausea and vomiting	symptoms
+789.1	Persistent vomiting	symptoms
+790	Nonspecific findings on examination of blood	symptoms
+790.1	Elevated sedimentation rate	symptoms
+790.6	Other abnormal blood chemistry	symptoms
+790.8	Elevated C-reactive protein (CRP)	symptoms
+790.9	Abnormal arterial blood gases	symptoms
+791	Gangrene	symptoms
+792	Abnormal Papanicolaou smear of cervix and cervical HPV	genitourinary
+792.1	Papanicolaou smear of cervix or vagina with atypical squamous cells	genitourinary
+793	Nonspecific abnormal findings on radiological and other examination of musculoskeletal system	symptoms
+793.2	"Nonspecific abnormal findings on radiological and other examination of other intrathoracic organs (echocardiogram, etc)"	symptoms
+794	"Abnormal results of other function studies (bladder, pancreas, placenta, spleen, etc)"	symptoms
+795	"Other and nonspecific abnormal cytological, histological and immunological findings"	symptoms
+795.8	Abnormal tumor markers	symptoms
+795.81	Elevated carcinoembryonic antigen [CEA]	symptoms
+795.82	Elevated cancer antigen 125 [CA 125]	symptoms
+796	Elevated prostate specific antigen [PSA]	genitourinary
+797	Shock	symptoms
+797.1	Cardiogenic shock	symptoms
+798	Malaise and fatigue	symptoms
+798.1	Chronic fatigue syndrome	symptoms
+799	Debility unspecified	symptoms
+800	Fracture of lower limb	injuries & poisonings
+800.1	Fracture of neck of femur	injuries & poisonings
+800.2	Fracture of unspecified part of femur	injuries & poisonings
+800.3	Fracture of tibia and fibula	injuries & poisonings
+800.4	Fracture of patella	injuries & poisonings
+801	Fracture of ankle and foot	injuries & poisonings
+801.1	Fracture of foot	injuries & poisonings
+802	Fracture of pelvis	injuries & poisonings
+803	Fracture of upper limb	injuries & poisonings
+803.1	Fracture of humerus	injuries & poisonings
+803.2	Fracture of radius and ulna	injuries & poisonings
+803.21	Colles' fracture	injuries & poisonings
+803.3	Fracture of clavicle or scapula	injuries & poisonings
+804	Fracture of hand or wrist	injuries & poisonings
+805	Fracture of vertebral column without mention of spinal cord injury	injuries & poisonings
+807	Fracture of ribs	injuries & poisonings
+809	Fracture of unspecified bones	injuries & poisonings
+816	Cerebral laceration and contusion	injuries & poisonings
+817	Concussion	injuries & poisonings
+818	Intracranial hemorrhage (injury)	injuries & poisonings
+818.1	Subdural hemorrhage (injury)	injuries & poisonings
+818.2	Subarachnoid hemorrhage (injury)	injuries & poisonings
+819	Skull and face fracture and other intercranial injury	injuries & poisonings
+823	Torus fracture	injuries & poisonings
+830	Dislocation	injuries & poisonings
+835	Internal derangement of knee	injuries & poisonings
+836	Traumatic arthropathy	injuries & poisonings
+840	Sprains and strains	injuries & poisonings
+840.1	Muscle/tendon sprain	injuries & poisonings
+840.2	Rotator cuff (capsule) sprain	injuries & poisonings
+840.3	Joint/ligament sprain	injuries & poisonings
+841	Sprains and strains of back and neck	injuries & poisonings
+842	Other sprains and strains	injuries & poisonings
+850	Hemorrhage or hematoma complicating a procedure	injuries & poisonings
+851	Complications of transplants and reattached limbs	injuries & poisonings
+853	Complication of colostomy or enterostomy	injuries & poisonings
+854	"Complications of cardiac/vascular device, implant, and graft"	injuries & poisonings
+855	"Complication of nervous system device, implant, and graft"	injuries & poisonings
+856	Vascular complications of surgery and medical procedures	injuries & poisonings
+857	"Mechanical complication of unspecified genitourinary device, implant, and graft"	injuries & poisonings
+858	Complication of internal orthopedic device	injuries & poisonings
+859	Complication due to other implant and internal device	injuries & poisonings
+860	Bone marrow or stem cell transplant	neoplasms
+870	Open wounds of head; neck; and trunk	injuries & poisonings
+870.1	Open wound or laceration of eye or eyelid	injuries & poisonings
+870.2	Open wound of ear	injuries & poisonings
+870.3	Other open wound of head and face	injuries & poisonings
+870.4	Open wound of nose and sinus	injuries & poisonings
+870.5	Open wound of lip and mouth	injuries & poisonings
+870.6	Open wound of neck	injuries & poisonings
+870.8	Open wound of genital organs	injuries & poisonings
+871	Open wounds of extremities	injuries & poisonings
+871.1	Open wound of hand except finger(s)	injuries & poisonings
+871.2	Open wound of finger(s)	injuries & poisonings
+871.3	Open wound of foot except toe(s) alone	injuries & poisonings
+871.4	Open wound of toe(s)	injuries & poisonings
+872	Traumatic amputation	injuries & poisonings
+873	Broken tooth	injuries & poisonings
+874	Complication of amputation stump	injuries & poisonings
+875	Non-healing surgical wound	injuries & poisonings
+876	Posttraumatic wound infection not elsewhere classified	injuries & poisonings
+905	Late effects of musculoskeletal and connective tissue injuries	injuries & poisonings
+906	Late effects of injuries to skin and subcutaneous tissues	injuries & poisonings
+907	Injuries to the nervous system	injuries & poisonings
+908	Late effects of other injuries	injuries & poisonings
+909	Late effects of external causes	injuries & poisonings
+910	"Superficial injury, infected"	injuries & poisonings
+911	Blister	injuries & poisonings
+912	Insect bite	injuries & poisonings
+913	Toxic effect of venom	injuries & poisonings
+915	Superficial injury without mention of infection	injuries & poisonings
+916	Contusion	injuries & poisonings
+930	Allergic reaction to food	injuries & poisonings
+931	Contact dermatitis and other eczema due to plants [except food]	dermatologic
+938	Dermatitis due to solar radiation	dermatologic
+938.1	Acute dermatitis due to solar radiation	dermatologic
+938.2	Chronic dermatitis due to solar radiation	dermatologic
+939	Atopic/contact dermatitis due to other or unspecified	dermatologic
+939.1	Contact and allergic dermatitis of eyelid	dermatologic
+941	Adverse reaction to serum or vaccine	injuries & poisonings
+942	Infusion and transfusion reaction	injuries & poisonings
+946	Anaphylactic shock NOS	injuries & poisonings
+947	Urticaria	dermatologic
+949	"Allergies, other"	injuries & poisonings
+949.1	Diaper or napkin rash	injuries & poisonings
+952	Spinal cord injury without evidence of spinal bone injury	injuries & poisonings
+957	Injury to other and unspecified nerves	injuries & poisonings
+958	Certain early complications of trauma or procedure	injuries & poisonings
+958.1	Postoperative shock	injuries & poisonings
+958.2	Traumatic and surgical subcutaneous emphysema	injuries & poisonings
+960	Poisoning by antibiotics	injuries & poisonings
+960.1	Adverse effects of antibacterials (not penicillins)	injuries & poisonings
+960.2	Allergy/adverse effect of penicillin	injuries & poisonings
+960.3	Poisoning by antifungal antibiotics	injuries & poisonings
+961	Poisoning by other anti-infectives	injuries & poisonings
+961.1	Poisoning/allergy of sulfonamides	injuries & poisonings
+962	Poisoning by hormones and synthetic substitutes	injuries & poisonings
+962.1	Adrenal cortical steroids causing adverse effects in therapeutic use	injuries & poisonings
+962.2	Insulins and antidiabetic agents causing adverse effects in therapeutic use	injuries & poisonings
+962.3	Hormones and synthetic substitutes causing adverse effects in therapeutic use	injuries & poisonings
+963	Poisoning by primarily systemic agents	injuries & poisonings
+963.1	Antineoplastic and immunosuppressive drugs causing adverse effects	injuries & poisonings
+964	Poisoning by agents primarily affecting blood constituents	injuries & poisonings
+964.1	Anticoagulants causing adverse effects	injuries & poisonings
+965	"Poisoning by analgesics, antipyretics, and antirheumatics"	injuries & poisonings
+965.1	Opiates and related narcotics causing adverse effects in therapeutic use	injuries & poisonings
+965.2	Antirheumatics causing adverse effects in therapeutic use	injuries & poisonings
+965.3	Salicylates causing adverse effects in therapeutic use	injuries & poisonings
+966	Poisoning by anticonvulsants and anti-Parkinsonism drugs	injuries & poisonings
+967	Adverse effects of sedatives or other central nervous system depressants and anesthetics	injuries & poisonings
+969	Poisoning by psychotropic agents	injuries & poisonings
+971	Poisoning by drugs primarily affecting the autonomic nervous system	injuries & poisonings
+972	Poisoning by agents primarily affecting the cardiovascular system	injuries & poisonings
+972.1	Cardiac rhythm regulators causing adverse effects in therapeutic use	injuries & poisonings
+972.2	Antilipemic and antiarteriosclerotic drugs causing adverse effects in therapeutic use	injuries & poisonings
+972.6	Antihypertensive agents causing adverse effects	injuries & poisonings
+973	Poisoning by agents primarily affecting the gastrointestinal system	injuries & poisonings
+974	"Poisoning by water, mineral, and uric acid metabolism drugs"	injuries & poisonings
+975	Poisoning by agents primarily acting on the smooth and skeletal muscles and respiratory system	injuries & poisonings
+976	"Poisoning by agents primarily affecting skin & mucous membrane, ophthalmological, otorhinolaryngological, & dental drugs"	injuries & poisonings
+977	Personal history of allergy to medicinal agents	injuries & poisonings
+979	Adverse drug events and drug allergies	injuries & poisonings
+980	Encounter for long-term (current) use of antibiotics	infectious diseases
+981	Toxic effect of (non-ethyl) alcohol and petroleum and other solvents	injuries & poisonings
+983	"Toxic effect of corrosive aromatics, acids, and caustic alkalis"	injuries & poisonings
+984	Toxic effect of lead and its compounds (including fumes)	injuries & poisonings
+985	Toxic effect of other metals	injuries & poisonings
+986	Toxic effect of carbon monoxide	injuries & poisonings
+987	"Toxic effect of other gases, fumes, or vapors"	injuries & poisonings
+988	Toxic effect of noxious substances eaten as food	injuries & poisonings
+989	"Toxic effect of other substances, chiefly nonmedicinal as to source"	injuries & poisonings
+990	Effects radiation NOS	injuries & poisonings
+994	Sepsis and SIRS	injuries & poisonings
+994.1	Systemic inflammatory response syndrome (SIRS)	injuries & poisonings
+994.2	Sepsis	injuries & poisonings
+994.21	Septic shock	injuries & poisonings
+996	Complications peculiar to certain specified procedures	injuries & poisonings

--- a/src/drive/phecode_mappings/phecodeX.txt
+++ b/src/drive/phecode_mappings/phecodeX.txt
@@ -1,0 +1,3613 @@
+phecode	phecode_string	category
+ID_001	Salmonella	Infections
+ID_002	Staphylococcus	Infections
+ID_002.1	Staphylococcus aureus	Infections
+ID_003	Escherichia coli	Infections
+ID_004	Streptococcus	Infections
+ID_004.1	Streptococcus pneumoniae	Infections
+ID_004.2	Group A Streptococcus	Infections
+ID_004.3	Group B Streptococcus	Infections
+ID_004.4	Scarlet fever	Infections
+ID_005	Mycobacteria	Infections
+ID_005.1	Mycobacterium tuberculosis	Infections
+ID_005.2	Disseminated mycobacterium avium-intracellulare complex (DMAC)*	Infections
+ID_005.3	Mycobacterium leprae [Leprosy]	Infections
+ID_006	Neisseria	Infections
+ID_006.1	Neisseria meningitidis	Infections
+ID_006.2	Neisseria gonorrhea	Infections
+ID_007	Hemophilus infection	Infections
+ID_007.1	Hemophilus influenzae	Infections
+ID_007.2	Haemophilus ducreyi	Infections
+ID_008	Helicobacter [H. pylori]	Infections
+ID_009	Pseudomonas	Infections
+ID_010	Corynebacterium	Infections
+ID_010.1	Corynebacterium diphtheriae	Infections
+ID_011	Klebsiella	Infections
+ID_012	Proteus	Infections
+ID_013	Mycoplasma	Infections
+ID_014	Bacteroides fragilis	Infections
+ID_015	Clostridium	Infections
+ID_015.1	Clostridium perfringens	Infections
+ID_015.2	Clostridium difficile	Infections
+ID_015.3	Clostridium botulinum	Infections
+ID_016	Chlamydia	Infections
+ID_016.1	Chlamydia trachomatis	Infections
+ID_016.2	Chlamydia psittaci	Infections
+ID_017	Bartonellosis	Infections
+ID_018	Serratia	Infections
+ID_019	Treponema	Infections
+ID_019.1	Treponema pallidum [syphilis]	Infections
+ID_019.2	Treponema carateum	Infections
+ID_020	Borrelia	Infections
+ID_020.1	Lyme disease	Infections
+ID_021	Rickettsia	Infections
+ID_021.2	Spotted fever	Infections
+ID_022	Ehrlichiosis	Infections
+ID_023	Vibrio	Infections
+ID_024	Pertussis	Infections
+ID_025	Enterococcus	Infections
+ID_026	Actinomyces and Nocardia	Infections
+ID_027	Shigella	Infections
+ID_028	Bacillus	Infections
+ID_029	Leptospira	Infections
+ID_030	Campylobacter	Infections
+ID_031	Listeria	Infections
+ID_032	Yersinia	Infections
+ID_033	Francisella	Infections
+ID_034	Brucella	Infections
+ID_035	Burkholderia	Infections
+ID_036	Spirillum	Infections
+ID_037	Streptobacillus	Infections
+ID_038	Erysipelothrix	Infections
+ID_039	Pasteurella	Infections
+ID_040	Legionella	Infections
+ID_041	Coxiella	Infections
+ID_042	Tropheryma	Infections
+ID_050	Enterovirus	Infections
+ID_050.1	Poliovirus	Infections
+ID_050.2	Coxsackie virus	Infections
+ID_050.3	ECHO virus	Infections
+ID_050.4	"Hand, foot, and mouth disease"	Infections
+ID_050.5	Enteroviral vesicular pharyngitis	Infections
+ID_050.6	Rhinovirus	Infections
+ID_052	Herpesvirus	Infections
+ID_052.1	Herpes simplex	Infections
+ID_052.3	Varicella zoster virus	Infections
+ID_052.31	Varicella [chickenpox]	Infections
+ID_052.32	Herpes zoster	Infections
+ID_052.4	Infectious mononucleosis	Infections
+ID_052.5	Cytomegalovirus [CMV]	Infections
+ID_052.6	Human herpesvirus 6	Infections
+ID_052.7	Human herpesvirus 7	Infections
+ID_053	Parvovirus	Infections
+ID_054	Hepatovirus	Infections
+ID_054.1	Hepatitis A	Infections
+ID_054.2	Hepatitis B	Infections
+ID_054.21	Hepatitis B with delta	Infections
+ID_054.3	Hepatitis C	Infections
+ID_054.31	Chronic hepatitis C	Infections
+ID_054.32	Acute hepatitis C	Infections
+ID_054.5	Hepatitis E	Infections
+ID_055	Poxvirus	Infections
+ID_055.1	Molluscum contagiosum	Infections
+ID_056	Human papillomavirus	Infections
+ID_056.1	Plantar wart	Infections
+ID_056.2	Anogenital (venereal) warts	Infections
+ID_057	Retrovirus	Infections
+ID_057.1	Human immunodeficiency virus	Infections
+ID_057.2	Human T-cell lymphotropic virus type 1*	Infections
+ID_058	Pneumoviridae	Infections
+ID_058.1	Respiratory syncytial virus	Infections
+ID_058.2	Human metapneumovirus*	Infections
+ID_059	Coronavirus	Infections
+ID_059.1	Sars-CoV-2*	Infections
+ID_060	Adenovirus	Infections
+ID_061	Influenza virus	Infections
+ID_061.1	Influenza A virus	Infections
+ID_062	Parainfluenza virus	Infections
+ID_063	Rotavirus	Infections
+ID_064	Norovirus	Infections
+ID_065	Measles virus	Infections
+ID_066	Orthorubulavirus [Mumps]	Infections
+ID_067	Rubella	Infections
+ID_068	Dengue virus	Infections
+ID_068.1	Dengue hemorrhagic fever*	Infections
+ID_069	Other specified viral infections	Infections
+ID_070	Candidiasis	Infections
+ID_070.4	Disseminated candidiasis	Infections
+ID_071	Coccidioides	Infections
+ID_072	Histoplasmosis	Infections
+ID_073	Blastomyces	Infections
+ID_074	Aspergillosis	Infections
+ID_075	Cryptococcosis	Infections
+ID_076	Pneumocystosis	Infections
+ID_078	Zygomycosis	Infections
+ID_079	Other specified fungal infections	Infections
+ID_084	Parasites	Infections
+ID_084.1	Amebiasis	Infections
+ID_084.2	Plasmodium [Malaria]	Infections
+ID_084.3	Leishmaniasis [Leishmania]	Infections
+ID_084.31	Visceral leishmaniasis	Infections
+ID_084.32	Cutaneous leishmaniasis	Infections
+ID_084.4	Trichomoniasis	Infections
+ID_084.5	Toxoplasmosis	Infections
+ID_084.6	Enterobiasis	Infections
+ID_084.7	Giardiasis	Infections
+ID_084.8	Cryptosporidiosis	Infections
+ID_086	"Pediculosis, acariasis and other infestations"	Infections
+ID_086.1	Pediculosis	Infections
+ID_086.2	Scabies	Infections
+ID_087	Infectious prions	Infections
+ID_088	Sexually transmitted disease	Infections
+ID_089	Infections	Infections
+ID_089.1	Bacterial infections	Infections
+ID_089.2	Viral infections	Infections
+ID_089.3	Fungal infections	Infections
+ID_091	Gangrene	Infections
+ID_092	"Bacteremia, Sepsis, and SIRS"	Infections
+ID_092.1	Systemic inflammatory response syndrome	Infections
+ID_092.2	Sepsis	Infections
+ID_092.3	Meningococcemia	Infections
+ID_092.5	Toxic shock syndrome	Infections
+ID_092.8	Bacteremia	Infections
+ID_097	Drug resistant microorganisms	Infections
+ID_097.1	Methicillin resistant Staphylococcus aureus	Infections
+ID_097.2	Resistance to penicillins	Infections
+ID_097.3	Resistance to beta lactam antibiotics	Infections
+CA_100	Malignant neoplasm of the head and neck	Neoplasms
+CA_100.1	Malignant neoplasm of the oral cavity	Neoplasms
+CA_100.12	Malignant neoplasm of the tongue	Neoplasms
+CA_100.13	Malignant neoplasm of the gums	Neoplasms
+CA_100.14	Malignant neoplasm of the floor of mouth	Neoplasms
+CA_100.15	Malignant neoplasm of the palate	Neoplasms
+CA_100.2	Malignant neoplasm of the oropharynx	Neoplasms
+CA_100.3	Malignant neoplasm of the nasopharynx	Neoplasms
+CA_100.4	Malignant neoplasm of the hypopharynx	Neoplasms
+CA_100.5	"Malignant neoplasm of nasal cavities, middle ear, and accessory sinuses"	Neoplasms
+CA_100.6	Malignant neoplasm of the larynx	Neoplasms
+CA_100.7	Malignant neoplasm of the pharynx	Neoplasms
+CA_100.8	Malignant neoplasm of the lip	Neoplasms
+CA_100.9	Malignant neoplasm of the salivary glands	Neoplasms
+CA_101	Malignant neoplasm of the digestive organs	Neoplasms
+CA_101.1	Malignant neoplasm of the esophagus	Neoplasms
+CA_101.2	Malignant neoplasm of stomach	Neoplasms
+CA_101.21	Malignant neoplasm of cardia	Neoplasms
+CA_101.3	Malignant neoplasm of the small intestine	Neoplasms
+CA_101.4	Malignant neoplasm of the lower GI tract	Neoplasms
+CA_101.41	Colorectal cancer	Neoplasms
+CA_101.411	Malignant neoplasm of colon	Neoplasms
+CA_101.412	Malignant neoplasm of appendix	Neoplasms
+CA_101.42	Malignant neoplasm of anus	Neoplasms
+CA_101.6	Malignant neoplasm of the liver and intrahepatic bile ducts	Neoplasms
+CA_101.61	Malignant neoplasm of the liver	Neoplasms
+CA_101.62	Malignant neoplasm of the intrahepatic bile ducts	Neoplasms
+CA_101.7	Malignant neoplasm of the gallbladder and extrahepatic bile ducts	Neoplasms
+CA_101.71	Malignant neoplasm of the gallbladder	Neoplasms
+CA_101.8	Malignant neoplasm of the pancreas	Neoplasms
+CA_102	Malignant neoplasm of the thoracic and respiratory organs	Neoplasms
+CA_102.1	Malignant neoplasm of the of bronchus and lung	Neoplasms
+CA_102.3	Malignant neoplasm of the trachea	Neoplasms
+CA_102.5	"Malignant neoplasm of the heart, mediastinum, thymus, and pleura"	Neoplasms
+CA_102.51	Malignant neoplasm of the heart	Neoplasms
+CA_102.52	Malignant neoplasm of the mediastinum	Neoplasms
+CA_102.53	Malignant neoplasm of the of pleura	Neoplasms
+CA_102.54	Malignant neoplasm of the thymus	Neoplasms
+CA_103	Malignant neoplasm of the skin	Neoplasms
+CA_103.1	Melanomas of skin	Neoplasms
+CA_103.2	Keratinocyte carcinoma	Neoplasms
+CA_103.21	Basal cell carcinoma	Neoplasms
+CA_103.22	Squamous cell carcinoma of the skin	Neoplasms
+CA_103.3	Carcinoma in situ of skin	Neoplasms
+CA_104	Malignant sarcoma-related cancers	Neoplasms
+CA_104.1	Malignant neoplam of the bone and/or cartilage	Neoplasms
+CA_104.2	Malignant neoplasm of retroperitoneum and peritoneum	Neoplasms
+CA_104.3	Malignant neoplasm of connective and soft tissue	Neoplasms
+CA_104.4	Malignant neoplasm of peripheral nerves*	Neoplasms
+CA_104.5	Gastrointestinal stromal tumor*	Neoplasms
+CA_104.6	Kaposi's sarcoma	Neoplasms
+CA_105	Malignant neoplasm of the breast	Neoplasms
+CA_105.1	"Malignant neoplasm of the breast, female"	Neoplasms
+CA_105.2	"Malignant neoplasm of the breast, male"	Neoplasms
+CA_106	Gynecological malignant neoplasms	Neoplasms
+CA_106.1	Malignant neoplasm of external female genital organs and cervix	Neoplasms
+CA_106.11	Malignant neoplasm of the vulva	Neoplasms
+CA_106.12	Malignant neoplasm of the vagina	Neoplasms
+CA_106.13	Malignant neoplasm of the cervix	Neoplasms
+CA_106.2	Malignant neoplasm of the uterus	Neoplasms
+CA_106.21	Malignant neoplasm of endometrium	Neoplasms
+CA_106.3	Malignant neoplasm of the ovary	Neoplasms
+CA_106.4	Malignant neoplasm of the fallopian tube and uterine adnexa	Neoplasms
+CA_106.6	Malignant neoplasm of the placenta	Neoplasms
+CA_107	Malignant neoplasm of male genitalia	Neoplasms
+CA_107.1	Malignant neoplasm of the penis	Neoplasms
+CA_107.2	Malignant neoplasm of the prostate	Neoplasms
+CA_107.3	Malignant neoplasm of the testis	Neoplasms
+CA_107.4	Malignant neoplasm of epididymis	Neoplasms
+CA_107.5	Malignant neoplasm of spermatic cord	Neoplasms
+CA_107.6	Malignant neoplasm of the scrotum	Neoplasms
+CA_108	Malignant neoplasm of the urinary tract	Neoplasms
+CA_108.4	Malignant neoplasm of the kidney	Neoplasms
+CA_108.41	"Malignant neoplasm of kidney, except pelvis"	Neoplasms
+CA_108.42	Malignant neoplasm of renal pelvis	Neoplasms
+CA_108.5	Malignant neoplasm of the bladder	Neoplasms
+CA_108.6	Malignant neoplasm of urethra	Neoplasms
+CA_108.7	Malignant neoplasm of ureter	Neoplasms
+CA_109	"Malignant neoplasm of the eye, brain and other parts of central nervous system"	Neoplasms
+CA_109.1	Malignant neoplasm of eye	Neoplasms
+CA_109.11	Malignant neoplasm of orbit	Neoplasms
+CA_109.12	Malignant neoplasm of lacrimal gland and duct	Neoplasms
+CA_109.13	Malignant neoplasm of conjunctiva	Neoplasms
+CA_109.14	Malignant neoplasm of cornea	Neoplasms
+CA_109.15	Malignant neoplasm of retina	Neoplasms
+CA_109.16	Malignant neoplasm of choroid	Neoplasms
+CA_109.2	Malignant neoplasm of meninges	Neoplasms
+CA_109.3	Malignant neoplasm of brain	Neoplasms
+CA_109.4	Malignant neoplasm of spinal cord	Neoplasms
+CA_109.5	Malignant neoplasm of cranial nerve	Neoplasms
+CA_110	Malignant neoplasm of the endocrine glands	Neoplasms
+CA_110.1	Malignant neoplasm of the thyroid	Neoplasms
+CA_110.3	Malignant neoplasm of the parathyroid gland	Neoplasms
+CA_110.4	Malignant neoplasm of the pituitary gland and craniopharyngeal duct	Neoplasms
+CA_110.5	Malignant neoplasm of the pineal gland	Neoplasms
+CA_112	Malignant neoplasm of other and ill-defined sites	Neoplasms
+CA_112.1	Mesothelioma*	Neoplasms
+CA_114	Neuroendocrine tumors	Neoplasms
+CA_114.1	Malignant neuroendocrine tumors	Neoplasms
+CA_114.11	Exocrine pancreatic cancer	Neoplasms
+CA_114.12	Merkel cell carcinoma	Neoplasms
+CA_114.2	Benign neuroendocrine tumors	Neoplasms
+CA_114.4	Carcinoid tumors	Neoplasms
+CA_114.41	Intestinal carcinoid	Neoplasms
+CA_114.42	Carcinoid tumor of the bronchus and lung	Neoplasms
+CA_114.43	Carcinoid tumor of the thymus	Neoplasms
+CA_114.44	Carcinoid tumor of the stomach	Neoplasms
+CA_114.45	Carcinoid tumor of the kidney	Neoplasms
+CA_114.5	Paraganglioma	Neoplasms
+CA_114.6	Pheochromocytoma	Neoplasms
+CA_116	Secondary malignant neoplasm	Neoplasms
+CA_120	Hemo onc - by cell of origin	Neoplasms
+CA_120.1	Myeloid	Neoplasms
+CA_120.11	Plasma cell	Neoplasms
+CA_120.12	Monocyte	Neoplasms
+CA_120.13	Erythroid	Neoplasms
+CA_120.14	Megakaryoblast	Neoplasms
+CA_120.15	Mast cell	Neoplasms
+CA_120.2	Lymphoid	Neoplasms
+CA_120.21	Mature B-cell	Neoplasms
+CA_120.22	Mature T-Cell	Neoplasms
+CA_120.3	Histocytoces	Neoplasms
+CA_121	Leukemia	Neoplasms
+CA_121.1	Acute leukemia	Neoplasms
+CA_121.11	Acute lymphoid leukemia	Neoplasms
+CA_121.12	Acute myeloid leukemia	Neoplasms
+CA_121.2	Chronic leukemia	Neoplasms
+CA_121.21	Chronic lymphoid leukemia	Neoplasms
+CA_121.22	Chronic myloid leukemia	Neoplasms
+CA_121.23	Chronic myelomonocytic (monocytic) leukemia	Neoplasms
+CA_122	Lymphoma	Neoplasms
+CA_122.1	Hodgkin lymphoma	Neoplasms
+CA_122.11	Nodular sclerosis Hodgkin lymphoma	Neoplasms
+CA_122.2	Non-Hodgkin lymphoma	Neoplasms
+CA_122.21	Follicular lymphoma	Neoplasms
+CA_122.22	Diffuse large B-cell lymphoma*	Neoplasms
+CA_122.23	Burkitt lymphoma	Neoplasms
+CA_122.24	T-cell lymphoma	Neoplasms
+CA_122.25	Anaplastic large cell lymphoma	Neoplasms
+CA_122.26	"Extranodal NK/T-cell lymphoma, nasal type*"	Neoplasms
+CA_123	Multiple myeloma and malignant plasma cell neoplasms	Neoplasms
+CA_123.1	Multiple myeloma	Neoplasms
+CA_124	Myeloproliferative disorder	Neoplasms
+CA_124.3	Polycythemia vera	Neoplasms
+CA_124.5	Essential thrombocythemia	Neoplasms
+CA_124.6	Myelodysplastic syndrome	Neoplasms
+CA_124.7	Chronic myeloproliferative disease*	Neoplasms
+CA_124.8	Myelofibrosis	Neoplasms
+CA_125	"Other malignant neoplasms of lymphoid, hematopoietic and related tissue"	Neoplasms
+CA_125.1	Cutaneous mastocytosis*	Neoplasms
+CA_128	Estrogen receptor status	Neoplasms
+CA_128.1	Estrogen receptor postitive status [ER+]	Neoplasms
+CA_128.2	Estrogen receptor negative status [ER-]	Neoplasms
+CA_130	"Cancer (solid tumor, excluding BCC)"	Neoplasms
+CA_132	Sequelae of cancer	Neoplasms
+CA_135	Benign neoplasm of the head and neck	Neoplasms
+CA_135.1	Benign neoplasm of the oral cavity	Neoplasms
+CA_135.11	Benign neoplasm of the lip	Neoplasms
+CA_135.12	Benign neoplasm of the tongue	Neoplasms
+CA_135.14	Benign neoplasm of the floor of mouth	Neoplasms
+CA_135.16	Benign neoplasm of the salivary glands	Neoplasms
+CA_135.2	Benign neoplasm of the oropharynx	Neoplasms
+CA_135.3	Benign neoplasm of the nasopharynx	Neoplasms
+CA_135.4	Benign neoplasm of the hypopharynx	Neoplasms
+CA_135.5	Benign neoplasm of the paranasal sinus and nasal cavity	Neoplasms
+CA_135.6	Benign neoplasm of vocal cord or larynx	Neoplasms
+CA_136	Benign neoplasm of the digestive organs	Neoplasms
+CA_136.1	Benign neoplasm of the esophagus	Neoplasms
+CA_136.2	Benign neoplasm of stomach	Neoplasms
+CA_136.3	Benign neoplasm of the small intestine	Neoplasms
+CA_136.4	"Benign neoplasm of colon, rectum, anus and anal canal"	Neoplasms
+CA_136.41	Benign neoplasm of the colon	Neoplasms
+CA_136.42	Benign neoplasm of rectum and anus	Neoplasms
+CA_136.6	Benign neoplasm of the liver and intrahepatic bile ducts	Neoplasms
+CA_136.61	Benign neoplasm of the liver*	Neoplasms
+CA_136.8	Benign neoplasm of the pancreas	Neoplasms
+CA_137	Benign neoplasm of the thoracic and respiratory organs	Neoplasms
+CA_137.1	Benign neoplasm of the of bronchus and lung	Neoplasms
+CA_137.3	Benign neoplasm of the trachea	Neoplasms
+CA_137.5	"Benign neoplasm of the heart, mediastinum, thymus, and pleura"	Neoplasms
+CA_137.51	Benign neoplasm of the heart	Neoplasms
+CA_137.52	Benign neoplasm of the mediastinum	Neoplasms
+CA_137.53	Benign neoplasm of the of pleura	Neoplasms
+CA_137.54	Benign neoplasm of the thymus	Neoplasms
+CA_138	Benign neoplasm of the skin	Neoplasms
+CA_138.1	"Nevus, non-neoplastic"	Neoplasms
+CA_138.2	Melanocytic nevi*	Neoplasms
+CA_139	Benign sarcoma-related cancers	Neoplasms
+CA_139.1	Benign neoplams of the bone and/or cartilage	Neoplasms
+CA_139.2	Benign neoplasm of retroperitoneum and peritoneum	Neoplasms
+CA_139.3	Benign neoplasm of other connective and soft tissue	Neoplasms
+CA_139.4	Benign neoplasm of peripheral nerves*	Neoplasms
+CA_139.5	Lipoma	Neoplasms
+CA_139.51	Lipomatosis*	Neoplasms
+CA_139.52	Lipoma of intrathoracic organs	Neoplasms
+CA_139.53	Lipoma of skin subcutaneous tissue	Neoplasms
+CA_139.54	Testicular limpoma	Neoplasms
+CA_139.6	Hemangioma and lymphangioma	Neoplasms
+CA_139.61	Hemangioma	Neoplasms
+CA_139.62	Lymphangioma	Neoplasms
+CA_140	Benign neoplasm of the breast	Neoplasms
+CA_142	Lump or mass in breast or nonspecific abnormal breast exam	Neoplasms
+CA_142.1	Lump or mass in breast	Neoplasms
+CA_142.2	Abnormal mammogram	Neoplasms
+CA_142.21	Mammographic microcalcification	Neoplasms
+CA_144	Gynecological benign neoplasms	Neoplasms
+CA_144.1	Benign neoplasms of external female genital organs and cervix	Neoplasms
+CA_144.11	Benign neoplasms of the vulva	Neoplasms
+CA_144.12	Benign neoplasms of the vagina	Neoplasms
+CA_144.13	Benign neoplasms of the cervix	Neoplasms
+CA_144.2	Benign neoplasms of the uterus	Neoplasms
+CA_144.21	Leiomyoma of uterus	Neoplasms
+CA_144.3	Benign neoplasms of the ovary	Neoplasms
+CA_144.4	Benign neoplasm of the fallopian tube and uterine adnexa	Neoplasms
+CA_146	Benign neoplasm of male genital organs	Neoplasms
+CA_146.1	Benign neoplasm of the penis	Neoplasms
+CA_146.2	Benign neoplasm of the prostate	Neoplasms
+CA_146.3	Benign neoplasm of the testis	Neoplasms
+CA_146.31	Benign neoplasm of epididymis and spermatic cord	Neoplasms
+CA_146.32	Benign neoplasm of the scrotum	Neoplasms
+CA_147	Benign neoplasm of kidney and urinary organs	Neoplasms
+CA_147.1	Benign neoplasm of the kidney	Neoplasms
+CA_147.2	Benign neoplasm of ureter	Neoplasms
+CA_147.3	Benign neoplasm of bladder	Neoplasms
+CA_147.4	Benign neoplasm of urethra	Neoplasms
+CA_148	"Benign neoplasm of the eye, brain and other parts of central nervous system"	Neoplasms
+CA_148.1	Benign neoplasm of eye	Neoplasms
+CA_148.11	Benign neoplasm of orbit	Neoplasms
+CA_148.12	Benign neoplasm of lacrimal gland and duct	Neoplasms
+CA_148.13	Benign neoplasm of conjunctiva	Neoplasms
+CA_148.14	Benign neoplasm of cornea	Neoplasms
+CA_148.15	Benign neoplasm of retina	Neoplasms
+CA_148.16	Benign neoplasm of choroid	Neoplasms
+CA_148.2	Benign neoplasm of meninges (Meningioma)	Neoplasms
+CA_148.3	Benign neoplasm of brain	Neoplasms
+CA_148.4	Benign neoplasm of spinal cord	Neoplasms
+CA_148.5	Benign neoplasm of cranial nerve	Neoplasms
+CA_149	Benign neoplasm of the endocrine glands	Neoplasms
+CA_149.1	Benign neoplasm of the thyroid	Neoplasms
+CA_149.3	Benign neoplasm of the parathyroid gland	Neoplasms
+CA_149.4	Benign neoplasm of the pituitary gland and craniopharyngeal duct	Neoplasms
+CA_149.5	Benign neoplasm of pineal gland	Neoplasms
+CA_152	Benign neoplasm of lymph nodes	Neoplasms
+CA_153	Benign neoplasm of other or unspecified sites	Neoplasms
+BI_160	Deficiency anemias	Blood/Immune
+BI_160.1	Iron deficiency anemia	Blood/Immune
+BI_160.11	Iron deficiency anemia secondary to blood loss	Blood/Immune
+BI_160.2	Megaloblastic anemia	Blood/Immune
+BI_160.21	Vitamin B12 deficiency anemia due to intrinsic factor deficiency [Pernicious anemia]	Blood/Immune
+BI_160.22	Folate-deficiency anemia	Blood/Immune
+BI_160.3	Protein-deficiency anemia	Blood/Immune
+BI_161	Hemolytic anemias (not specified as genetic)	Blood/Immune
+BI_161.2	Extrinsic (acquired) hemolytic anemias	Blood/Immune
+BI_161.21	Autoimmune hemolytic anemias [AIHA]	Blood/Immune
+BI_161.22	Hemolytic-uremic syndrome	Blood/Immune
+BI_161.23	Drug-induced hemolytic anemia*	Blood/Immune
+BI_162	Aplastic anemia	Blood/Immune
+BI_162.1	Constitutional (hereditary) aplastic anemia	Blood/Immune
+BI_162.2	Acquired pure red cell aplasia [erythroblastopenia]	Blood/Immune
+BI_162.3	Aplastic anemia due to drugs or other external agents*	Blood/Immune
+BI_162.4	Idiopathic aplastic anemia*	Blood/Immune
+BI_162.8	Pancytopenia	Blood/Immune
+BI_162.81	Drug-induced pancytopenia	Blood/Immune
+BI_164	Anemia	Blood/Immune
+BI_164.1	Microcytic anemia	Blood/Immune
+BI_164.2	Macrocytic anemia	Blood/Immune
+BI_164.3	Acute posthemorrhagic anemia	Blood/Immune
+BI_164.6	Anemia secondary to chronic diseases and conditions	Blood/Immune
+BI_164.7	Myelophthisis	Blood/Immune
+BI_164.8	Sideroblastic anemia	Blood/Immune
+BI_168	"Coagulation defects, purpura and other hemorrhagic conditions"	Blood/Immune
+BI_168.1	Hypo-coagulability	Blood/Immune
+BI_168.12	Hemorrhagic disorder due to intrinsic circulating anticoagulants	Blood/Immune
+BI_168.15	Acquired coagulation factor deficiency	Blood/Immune
+BI_168.18	Other nonthrombocytopenic purpura	Blood/Immune
+BI_168.2	Hyper-coagulability	Blood/Immune
+BI_168.21	Primary thrombophilia	Blood/Immune
+BI_168.211	Activated protein C resistance*	Blood/Immune
+BI_168.213	Lupus anticoagulant syndrome*	Blood/Immune
+BI_168.214	Antiphospholipid syndrome*	Blood/Immune
+BI_168.22	Disseminated intravascular coagulation [Defibrination syndrome]	Blood/Immune
+BI_168.3	Spontaneous ecchymoses	Blood/Immune
+BI_168.4	Abnormal coagulation profile	Blood/Immune
+BI_169	Platelet defects	Blood/Immune
+BI_169.1	Thrombocytopenia	Blood/Immune
+BI_169.11	Immune thrombocytopenic purpura [ITP]	Blood/Immune
+BI_169.12	Evans syndrome	Blood/Immune
+BI_169.13	Congenital and hereditary thrombocytopenic purpura	Blood/Immune
+BI_169.14	Secondary thrombocytopenia	Blood/Immune
+BI_169.15	Heparin-induced thrombocytopenia [HIT]	Blood/Immune
+BI_169.2	Qualitative platelet defects	Blood/Immune
+BI_170	Decreased white blood cell count	Blood/Immune
+BI_170.1	Neutropenia	Blood/Immune
+BI_170.12	Drug induced neutropenia	Blood/Immune
+BI_170.13	Neutropenia due to infection	Blood/Immune
+BI_170.14	Cyclic neutropenia	Blood/Immune
+BI_170.2	Lymphocytopenia	Blood/Immune
+BI_171	Elevated white blood cell count [Leukocytosis]	Blood/Immune
+BI_171.1	Lymphocytosis (symptomatic)	Blood/Immune
+BI_171.2	Monocytosis (symptomatic)	Blood/Immune
+BI_171.3	Plasmacytosis	Blood/Immune
+BI_171.4	Leukemoid reaction	Blood/Immune
+BI_171.5	Basophilia	Blood/Immune
+BI_171.6	Bandemia	Blood/Immune
+BI_171.7	Eosinophilia	Blood/Immune
+BI_171.71	Hypereosinophilic syndrome*	Blood/Immune
+BI_171.711	Idiopathic hypereosinophilic syndrome*	Blood/Immune
+BI_172	Other disorders of white blood cells	Blood/Immune
+BI_172.1	Functional disorders of polymorphonuclear neutrophils	Blood/Immune
+BI_172.3	Hemophagocytic syndromes	Blood/Immune
+BI_174	Diseases of spleen	Blood/Immune
+BI_174.1	Hyposplenism*	Blood/Immune
+BI_174.2	Splenomegaly	Blood/Immune
+BI_174.21	Hypersplenism	Blood/Immune
+BI_174.22	Chronic congestive splenomegaly	Blood/Immune
+BI_174.23	Neutropenic splenomegaly	Blood/Immune
+BI_174.5	Abscess of spleen*	Blood/Immune
+BI_174.6	Cyst of spleen*	Blood/Immune
+BI_174.7	Infarction of spleen*	Blood/Immune
+BI_175	Polycythemias	Blood/Immune
+BI_175.2	Secondary polycythemia	Blood/Immune
+BI_176	Other diseases of blood and blood-forming organs	Blood/Immune
+BI_176.1	Thrombocytosis*	Blood/Immune
+BI_177	Abnormality of the lymph nodes	Blood/Immune
+BI_177.1	Lymphadenitis	Blood/Immune
+BI_177.11	Mesenteric lymphadenitis	Blood/Immune
+BI_177.12	Chronic lymphadenitis	Blood/Immune
+BI_177.13	Acute lymphadenitis	Blood/Immune
+BI_177.2	Enlargement of lymph nodes [Lymphadenopathy]	Blood/Immune
+BI_177.3	Lymphangitis	Blood/Immune
+BI_177.4	Lymphedema	Blood/Immune
+BI_177.41	Hereditary lymphedema	Blood/Immune
+BI_179	Immunodeficiencies	Blood/Immune
+BI_179.1	Hypogammaglobulinemia NOS	Blood/Immune
+BI_179.4	Selective deficiency of immunoglobulin A [IgA]	Blood/Immune
+BI_179.5	Selective deficiency of immunoglobulin M [IgM]	Blood/Immune
+BI_179.6	Selective deficiency of immunoglobulin G [IgG] subclasses*	Blood/Immune
+BI_179.7	Common variable immunodeficiency [CVID]	Blood/Immune
+BI_179.8	Immunodeficiency with increased IgM	Blood/Immune
+BI_179.9	Immunodeficiency NOS	Blood/Immune
+BI_180	Other disorders involving the immune mechanism	Blood/Immune
+BI_180.2	Polyclonal hypergammaglobulinemia	Blood/Immune
+BI_180.3	Paraproteinemias	Blood/Immune
+BI_180.31	Monoclonal gammopathy	Blood/Immune
+BI_180.33	Macroglobulinemia [Waldenstrom macroglobulinemia]	Blood/Immune
+BI_180.34	Heavy chain disease*	Blood/Immune
+BI_180.4	Cryoglobulinemia*	Blood/Immune
+BI_180.6	Mast cell activation syndrome [MCAS]*	Blood/Immune
+BI_180.7	Cytokine release syndrome*	Blood/Immune
+BI_181	Autoimmune disease	Blood/Immune
+EM_200	Disorders of thyroid gland	Endocrine/Metab
+EM_200.1	Hypothyroidism	Endocrine/Metab
+EM_200.11	Secondary hypothyroidism	Endocrine/Metab
+EM_200.12	Hypothyroidism (not specified as secondary)	Endocrine/Metab
+EM_200.16	Myxedema*	Endocrine/Metab
+EM_200.2	Goiter	Endocrine/Metab
+EM_200.21	Diffuse goiter	Endocrine/Metab
+EM_200.22	Uninodular goiter [single thyroid nodule]	Endocrine/Metab
+EM_200.23	Multinodular goiter	Endocrine/Metab
+EM_200.24	Ectopic thyroid nodule	Endocrine/Metab
+EM_200.25	Dyshormogenetic goiter	Endocrine/Metab
+EM_200.3	Thyrotoxicosis [hyperthyroidism]	Endocrine/Metab
+EM_200.31	Graves' disease [Toxic diffuse goiter]	Endocrine/Metab
+EM_200.4	Thyroiditis	Endocrine/Metab
+EM_200.41	Chronic thyroiditis	Endocrine/Metab
+EM_200.411	Hashimoto thyroiditis [Chronic lymphocytic thyroiditis]	Endocrine/Metab
+EM_200.42	Acute thyroiditis	Endocrine/Metab
+EM_200.43	Subacute thyroiditis	Endocrine/Metab
+EM_200.45	Drug-induced/iatrogenic thyroiditis	Endocrine/Metab
+EM_200.5	Disorders of thyrocalcitonin secretion	Endocrine/Metab
+EM_200.6	Atrophy of thyroid*	Endocrine/Metab
+EM_200.7	Iodine-related thyroid disorders	Endocrine/Metab
+EM_200.8	Sick-euthyroid syndrome	Endocrine/Metab
+EM_200.9	Abnormal thyroid function studies	Endocrine/Metab
+EM_202	Diabetes mellitus	Endocrine/Metab
+EM_202.1	Type 1 diabetes	Endocrine/Metab
+EM_202.2	Type 2 diabetes	Endocrine/Metab
+EM_202.3	Secondary diabetes	Endocrine/Metab
+EM_202.31	Diabetes mellitus due to underlying condition*	Endocrine/Metab
+EM_202.32	Drug or chemical induced diabetes mellitus*	Endocrine/Metab
+EM_202.4	Other specified diabetes*	Endocrine/Metab
+EM_203	Metabolic syndrome [Dysmetabolic syndrome X]	Endocrine/Metab
+EM_204	Abnormal glucose	Endocrine/Metab
+EM_204.1	Impaired fasting glucose	Endocrine/Metab
+EM_204.2	Impaired glucose tolerance (oral)	Endocrine/Metab
+EM_204.3	Hypoglycemia	Endocrine/Metab
+EM_204.31	Hypoglycemic coma	Endocrine/Metab
+EM_204.32	Drug-induced hypoglycemia*	Endocrine/Metab
+EM_204.4	Hyperglycemia	Endocrine/Metab
+EM_204.5	Prediabetes*	Endocrine/Metab
+EM_206	Disorders of pancreatic internal secretion (excl. DM)	Endocrine/Metab
+EM_206.1	Abnormality of secretion of glucagon	Endocrine/Metab
+EM_206.2	Abnormality of secretion of gastrin	Endocrine/Metab
+EM_208	Disorders of parathyroid gland	Endocrine/Metab
+EM_208.1	Hypoparathyroidism	Endocrine/Metab
+EM_208.2	Hyperparathyroidism	Endocrine/Metab
+EM_208.22	Secondary hyperparathyroidism	Endocrine/Metab
+EM_209	Disorders of the pituitary gland and its hypothalamic control	Endocrine/Metab
+EM_209.1	Pituitary hyperfunction	Endocrine/Metab
+EM_209.11	"Tall stature, acromegaly and gigantism"	Endocrine/Metab
+EM_209.12	Syndrome of inappropriate secretion of antidiuretic hormone	Endocrine/Metab
+EM_209.13	Hyperprolactinemia*	Endocrine/Metab
+EM_209.14	Pituitary-dependent Cushing's disease*	Endocrine/Metab
+EM_209.2	Hypopituitarism	Endocrine/Metab
+EM_209.23	Iatrogenic hypopituitarism*	Endocrine/Metab
+EM_209.3	Hypothalamic dysfunction*	Endocrine/Metab
+EM_209.4	Diabetes insipidus	Endocrine/Metab
+EM_211	Disorders of adrenal glands	Endocrine/Metab
+EM_211.1	Adrenal hyperfunction	Endocrine/Metab
+EM_211.11	Hyperaldosteronism	Endocrine/Metab
+EM_211.13	Cushing's syndrome	Endocrine/Metab
+EM_211.131	Drug-induced Cushing's syndrome*	Endocrine/Metab
+EM_211.132	Nelson's syndrome*	Endocrine/Metab
+EM_211.133	Ectopic ACTH syndrome*	Endocrine/Metab
+EM_211.14	Medulloadrenal hyperfunction	Endocrine/Metab
+EM_211.2	Adrenocortical insufficiency	Endocrine/Metab
+EM_211.22	Drug-induced adrenocortical insufficiency*	Endocrine/Metab
+EM_211.23	Postprocedural adrenocortical (-medullary) hypofunction*	Endocrine/Metab
+EM_211.3	Adrenogenital disorders	Endocrine/Metab
+EM_214	Disorders of ovarian function	Endocrine/Metab
+EM_214.1	Ovarian failure	Endocrine/Metab
+EM_214.11	Premature menopause	Endocrine/Metab
+EM_214.12	Postablative ovarian failure	Endocrine/Metab
+EM_214.2	Ovarian hyperfunction	Endocrine/Metab
+EM_214.21	Estrogen excess (Hyperestrogenism)	Endocrine/Metab
+EM_214.22	Androgen excess*	Endocrine/Metab
+EM_215	Testicular dysfunction	Endocrine/Metab
+EM_215.1	Testicular hypofunction	Endocrine/Metab
+EM_215.2	Testicular hyperfunction	Endocrine/Metab
+EM_217	Disorders of puberty	Endocrine/Metab
+EM_217.1	Delayed puberty	Endocrine/Metab
+EM_217.2	Precocious puberty	Endocrine/Metab
+EM_218	Polyglandular dysfunction	Endocrine/Metab
+EM_218.2	Polyglandular dysfunction	Endocrine/Metab
+EM_218.21	Autoimmune polyglandular failure*	Endocrine/Metab
+EM_218.22	Polyglandular hyperfunction*	Endocrine/Metab
+EM_220	Diseases of thymus gland	Endocrine/Metab
+EM_220.1	Persistent hyperplasia of thymus	Endocrine/Metab
+EM_220.2	Abscess of thymus	Endocrine/Metab
+EM_228	Abnormal results of endocrine function studies (excluding thyroid)	Endocrine/Metab
+EM_229	"Other endocrine disorders, NOS"	Endocrine/Metab
+EM_229.1	"Ectopic hormone secretion, NEC"	Endocrine/Metab
+EM_230	Malnutrition and underweight	Endocrine/Metab
+EM_230.1	Protein-calorie malnutrition	Endocrine/Metab
+EM_230.2	Abnormal weight loss and underweight	Endocrine/Metab
+EM_230.21	Abnormal weight loss	Endocrine/Metab
+EM_230.22	Underweight	Endocrine/Metab
+EM_230.3	Anorexia	Endocrine/Metab
+EM_230.4	Cachexia	Endocrine/Metab
+EM_230.5	Early satiety	Endocrine/Metab
+EM_230.7	Failure to thrive	Endocrine/Metab
+EM_232	Vitamin deficiencies	Endocrine/Metab
+EM_232.1	Vitamin A deficiency	Endocrine/Metab
+EM_232.2	Vitamin B group deficiency	Endocrine/Metab
+EM_232.21	Thiamine deficiency [Vitamin B1]	Endocrine/Metab
+EM_232.22	Riboflavin deficiency [Vitamin B2]	Endocrine/Metab
+EM_232.23	Niacin deficiency [Vitamin B3]	Endocrine/Metab
+EM_232.26	Pyridoxine deficiency [Vitamin B6]	Endocrine/Metab
+EM_232.27	Vitamin B12 deficiency	Endocrine/Metab
+EM_232.29	Folate deficiency [Vitamin B9]	Endocrine/Metab
+EM_232.3	Vitamin C deficiency [Ascorbic acid]	Endocrine/Metab
+EM_232.4	Vitamin D deficiency	Endocrine/Metab
+EM_232.5	Vitamin E deficiency*	Endocrine/Metab
+EM_232.6	Vitamin K deficiency	Endocrine/Metab
+EM_234	Other nutritional deficiencies	Endocrine/Metab
+EM_234.1	Essential fatty acid [EFA] deficiency*	Endocrine/Metab
+EM_236	Overweight and obesity	Endocrine/Metab
+EM_236.1	Obesity	Endocrine/Metab
+EM_236.11	Morbid obesity	Endocrine/Metab
+EM_236.2	Localized adiposity	Endocrine/Metab
+EM_237	Abnormal weight gain	Endocrine/Metab
+EM_238	Micronutrient excess	Endocrine/Metab
+EM_238.1	Hypervitaminosis A	Endocrine/Metab
+EM_238.2	Hypercarotenemia	Endocrine/Metab
+EM_238.3	Megavitamin-B6 syndrome*	Endocrine/Metab
+EM_238.4	Hypervitaminosis D	Endocrine/Metab
+EM_239	Hyperlipidemia	Endocrine/Metab
+EM_239.1	Hypercholesterolemia	Endocrine/Metab
+EM_239.11	Pure hypercholesterolemia	Endocrine/Metab
+EM_239.13	Elevated Lipoprotein(a)*	Endocrine/Metab
+EM_239.2	Hyperglyceridemia	Endocrine/Metab
+EM_239.21	Pure hyperglyceridemia	Endocrine/Metab
+EM_239.3	Mixed hyperlipidemia	Endocrine/Metab
+EM_239.4	Hyperchylomicronemia	Endocrine/Metab
+EM_244	Disorders of lipoprotein metabolism and other lipidemias	Endocrine/Metab
+EM_244.4	"Lipodystrophy, not elsewhere classified"	Endocrine/Metab
+EM_247	Disorders of mineral metabolism and mineral deficiencies	Endocrine/Metab
+EM_247.2	Disorders of copper metabolism	Endocrine/Metab
+EM_247.3	Disorders of phosphorus metabolism	Endocrine/Metab
+EM_247.4	Disorders of magnesium metabolism	Endocrine/Metab
+EM_247.41	Hypermagnesemia*	Endocrine/Metab
+EM_247.42	Hypomagnesemia*	Endocrine/Metab
+EM_247.5	Disorders of calcium metabolism	Endocrine/Metab
+EM_247.51	Hypocalcemia	Endocrine/Metab
+EM_247.52	Hypercalcemia	Endocrine/Metab
+EM_247.53	Calcinosis cutis*	Endocrine/Metab
+EM_247.54	Hungry bone syndrome	Endocrine/Metab
+EM_247.55	Dietary calcium deficiency*	Endocrine/Metab
+EM_247.6	Metabolic disorders of zinc metabolism*	Endocrine/Metab
+EM_247.7	Disorders of iron metabolism	Endocrine/Metab
+EM_247.71	Hemochromatosis	Endocrine/Metab
+EM_247.8	Mineral deficiencies	Endocrine/Metab
+EM_247.81	Dietary selenium deficiency*	Endocrine/Metab
+EM_247.82	Manganese deficiency*	Endocrine/Metab
+EM_247.83	Chromium deficiency*	Endocrine/Metab
+EM_247.84	Molybdenum deficiency*	Endocrine/Metab
+EM_247.85	Vanadium deficiency*	Endocrine/Metab
+EM_247.86	Dietary zinc deficiency*	Endocrine/Metab
+EM_247.87	Copper deficiency*	Endocrine/Metab
+EM_247.88	Iron deficiency	Endocrine/Metab
+EM_248	"Disorders of plasma-protein metabolism, NEC"	Endocrine/Metab
+EM_249	Amyloidosis	Endocrine/Metab
+EM_249.1	Cerebral amyloid angiopathy*	Endocrine/Metab
+EM_249.2	Light chain (AL) amyloidosis*	Endocrine/Metab
+EM_249.3	Wild-type transthyretin-related (ATTRwt) amyloidosis*	Endocrine/Metab
+EM_252	Other and unspecified disorders of metabolism	Endocrine/Metab
+EM_252.1	Disorders of carnitine metabolism	Endocrine/Metab
+EM_252.2	Hyperphenylalaninemia	Endocrine/Metab
+EM_252.3	Disorders of bilirubin excretion	Endocrine/Metab
+EM_252.31	Biliuria	Endocrine/Metab
+EM_252.4	Hyperuricemia without signs of gout*	Endocrine/Metab
+EM_252.5	Disorders of carbohydrate metabolism	Endocrine/Metab
+EM_252.51	Disorders of intestinal carbohydrate absorption	Endocrine/Metab
+EM_256	"Disorders of fluid, electrolyte and acid-base balance"	Endocrine/Metab
+EM_256.1	Hyperosmolality and/or hypernatremia	Endocrine/Metab
+EM_256.2	Hyposmolality and/or hyponatremia	Endocrine/Metab
+EM_256.3	Mixed disorder of acid-base balance	Endocrine/Metab
+EM_256.31	Acidosis	Endocrine/Metab
+EM_256.32	Alkalosis	Endocrine/Metab
+EM_256.4	Hyperkalemia [Hyperpotassemia]	Endocrine/Metab
+EM_256.5	Hypokalemia [Hypopotassemia]	Endocrine/Metab
+EM_256.6	Fluid overload	Endocrine/Metab
+EM_256.7	Volume depletion	Endocrine/Metab
+EM_256.71	Dehydration	Endocrine/Metab
+EM_256.72	Hypovolemia	Endocrine/Metab
+EM_257	Polydipsia	Endocrine/Metab
+MB_280	Psychoactive substance related disorders	Mental
+MB_280.1	Alcohol use disorders	Mental
+MB_280.11	Alcohol abuse and dependence	Mental
+MB_280.13	Alcoholic liver disease	Mental
+MB_280.2	Opioid use disorders	Mental
+MB_280.21	Opioid abuse or dependence	Mental
+MB_280.3	Cannabis use disorders	Mental
+MB_280.31	Cannabis abuse or dependance	Mental
+MB_280.4	"Sedative, hypnotic, or anxiolytic related disorders"	Mental
+MB_280.41	"Sedative, hypnotic or anxiolytic-related abuse or dependance"	Mental
+MB_280.5	Stimulant use disorders	Mental
+MB_280.51	Stimulant abuse or dependance	Mental
+MB_280.7	Hallucinogen related disorders	Mental
+MB_280.71	Hallucinogen abuse or dependence	Mental
+MB_280.8	Psychoactive substance abuse	Mental
+MB_280.9	Psychoactive substance dependance	Mental
+MB_280.91	Psychoactive substance withdrawal	Mental
+MB_281	Abuse of non-psychoactive substances*	Mental
+MB_282	Nicotine dependence (current and history of)	Mental
+MB_282.1	Current tobacco use and nicotine dependence	Mental
+MB_282.2	Personal history of nicotine dependence	Mental
+MB_283	Other mental and behavioral problems	Mental
+MB_283.1	Symptoms and signs involving appearance and behavior*	Mental
+MB_283.3	High risk sexual behavior	Mental
+MB_283.4	Patient's noncompliance with medical treatment and regimen	Mental
+MB_283.8	Problems related to lifestyle	Mental
+MB_284	Suicide ideation and attempt or self harm	Mental
+MB_284.1	Suicidal ideations	Mental
+MB_284.2	Suicide and self-inflicted harm	Mental
+MB_284.3	Nonsuicidal self-harm*	Mental
+MB_286	Mood [affective] disorders	Mental
+MB_286.1	Bipolar disorder	Mental
+MB_286.11	Bipolar I disorder	Mental
+MB_286.12	Bipolar II disorder*	Mental
+MB_286.2	Major depressive disorder	Mental
+MB_286.3	Premenstrual dysphoric disorder	Mental
+MB_286.4	Dysthymic disorder	Mental
+MB_287	Psychotic disorder	Mental
+MB_287.1	Schizophrenia	Mental
+MB_287.2	Schizoaffective disorder	Mental
+MB_287.4	Delusional disorders	Mental
+MB_287.5	Drug-induced psychotic disorder	Mental
+MB_288	Anxiety and anxiety disorders	Mental
+MB_288.2	Panic disorder [episodic paroxysmal anxiety]	Mental
+MB_288.3	Generalized anxiety disorder	Mental
+MB_288.4	Phobic disorders	Mental
+MB_288.41	Agoraphobia	Mental
+MB_288.42	Social phobia	Mental
+MB_288.5	Drug induced anxiety disorder*	Mental
+MB_289	Obsessive-compulsive disorder	Mental
+MB_290	"Reaction to severe stress, and adjustment disorders"	Mental
+MB_290.1	Posttraumatic stress disorder	Mental
+MB_291	Dissociative and somatoform disorders	Mental
+MB_291.1	Conversion disorder	Mental
+MB_293	Eating disorders	Mental
+MB_293.1	Anorexia nervosa	Mental
+MB_293.2	Bulimia nervosa	Mental
+MB_293.3	Binge eating disorder*	Mental
+MB_293.4	Polyphagia	Mental
+MB_293.5	Pica	Mental
+MB_294	Sexual dysfunction and disorders	Mental
+MB_296	Personality disorders	Mental
+MB_296.1	Paranoid personality disorder	Mental
+MB_296.2	Schizoid personality disorder	Mental
+MB_296.3	Antisocial personality disorder	Mental
+MB_296.4	Borderline personality disorder	Mental
+MB_296.5	Histrionic personality disorder	Mental
+MB_296.6	Avoidant personality disorder	Mental
+MB_296.7	Dependent personality disorder	Mental
+MB_296.8	Narcissistic personality disorder	Mental
+MB_297	Gender identity disorder	Mental
+MB_298	Impulse disorders	Mental
+MB_298.1	Intermittent explosive disorder	Mental
+MB_298.2	Pathological gambling	Mental
+MB_298.3	Trichotillomania*	Mental
+MB_299	"Mental disorder, not otherwise specified"	Mental
+MB_300	Intellectual disabilities	Mental
+MB_300.1	Mild intellectual disabilities	Mental
+MB_300.2	Moderate intellectual disabilities	Mental
+MB_300.3	Severe intellectual disabilities	Mental
+MB_300.4	Profound intellectual disabilities	Mental
+MB_301	Pervasive developmental disorders	Mental
+MB_301.1	Autism	Mental
+MB_301.2	Asperger's syndrome*	Mental
+MB_302	Developemental delay	Mental
+MB_302.1	Speech and language developmental delay	Mental
+MB_302.11	Expressive language disorder	Mental
+MB_302.12	Mixed receptive-expressive language disorder	Mental
+MB_302.13	Phonological disorder*	Mental
+MB_302.2	Specific developmental disorder of motor function	Mental
+MB_302.3	Specific developmental disorders of scholastic skills	Mental
+MB_302.4	Delayed milestones	Mental
+MB_303	Symbolic dysfunctions	Mental
+MB_303.1	Dyslexia and alexia	Mental
+MB_304	Attention-deficit hyperactivity disorders	Mental
+MB_305	Stereotyped movement disorders	Mental
+MB_305.1	Tics and tic disorders	Mental
+MB_305.11	Tourette's disorder	Mental
+MB_305.12	Chronic motor or vocal tic disorder	Mental
+MB_305.13	Transient tic disorder	Mental
+MB_305.14	Tics of organic origin	Mental
+MB_306	Conduct disorders	Mental
+MB_307	Behavioral and emotional disorders with onset usually in childhood and adolescence	Mental
+MB_307.3	Emotional disturbance of childhood or adolescence	Mental
+MB_307.4	Disorders of social functioning with onset in childhood and adolescence	Mental
+MB_308	Symptoms related to mental disorders	Mental
+MB_308.1	Delirium	Mental
+MB_308.2	Delusions	Mental
+MB_308.3	Hallucinations	Mental
+MB_308.31	Visual hallucinations	Mental
+MB_308.32	Auditory hallucinations*	Mental
+MB_308.4	Neurocognitive disorder*	Mental
+MB_309	Signs and symptoms involving emotional state	Mental
+MB_309.1	Irritability	Mental
+MB_309.2	Impulsiveness	Mental
+MB_309.3	Emotional lability	Mental
+MB_309.4	Demoralization and apathy	Mental
+MB_309.5	Nervousness	Mental
+MB_309.6	"Excessive crying of child, adolescent, or adult"	Mental
+MB_309.7	Restlessness and agitation*	Mental
+MB_309.8	Homicidal ideations	Mental
+MB_309.9	Hostility and violent behavior*	Mental
+NS_320	Meningitis	Neurological
+NS_320.1	Infective meningitis	Neurological
+NS_320.11	Bacterial meningitis	Neurological
+NS_320.12	Viral meningitis	Neurological
+NS_320.13	Fungal memingitis	Neurological
+NS_320.2	Meningitis due to other non-infectious causes	Neurological
+NS_320.21	Nonpyogenic meningitis	Neurological
+NS_320.22	Chronic meningitis	Neurological
+NS_321	"Encephalitis, myelitis and encephalomyelitis"	Neurological
+NS_321.1	Encephalitis	Neurological
+NS_321.11	Bacterial encephalitis	Neurological
+NS_321.12	Viral encephalitis	Neurological
+NS_321.13	Toxoplasmosis meningoencephalitis	Neurological
+NS_321.14	Acute disseminated encephalitis and encephalomyelitis (ADEM)	Neurological
+NS_321.2	Myelitis	Neurological
+NS_321.21	Acute (transverse) myelitis	Neurological
+NS_322	Other CNS infection	Neurological
+NS_322.1	Prion diseases	Neurological
+NS_322.2	Progressive multifocal leukoencephalopathy	Neurological
+NS_322.4	Intracranial and intraspinal abscess	Neurological
+NS_323	Systemic atrophies primarily affecting the central nervous system	Neurological
+NS_323.3	Motor neuron disease	Neurological
+NS_323.31	Amyotrophic lateral sclerosis [ALS]	Neurological
+NS_323.32	Progressive bulbar palsy	Neurological
+NS_323.33	Primary lateral sclerosis	Neurological
+NS_324	Extrapyramidal and movement disorders	Neurological
+NS_324.1	Parkinsonism	Neurological
+NS_324.11	Parkinson's disease (Primary)	Neurological
+NS_324.2	Degenerative diseases of the basal ganglia (excluding parkinsonism)	Neurological
+NS_324.21	Progressive supranuclear ophthalmoplegia [Steele-Richardson-Olszewski]*	Neurological
+NS_324.3	Abnormal involuntary movements	Neurological
+NS_324.31	Dystonia	Neurological
+NS_324.311	Drug induced dystonia	Neurological
+NS_324.314	Torticollis	Neurological
+NS_324.315	Idiopathic orofacial dystonia	Neurological
+NS_324.316	Blepharospasm	Neurological
+NS_324.32	Abnormal head movements*	Neurological
+NS_324.33	Fasciculation*	Neurological
+NS_324.34	Tremor	Neurological
+NS_324.341	Essential tremor*	Neurological
+NS_324.342	Drug-induced tremor*	Neurological
+NS_324.35	Myoclonus	Neurological
+NS_324.5	Benign shuddering attacks	Neurological
+NS_324.6	Tetany	Neurological
+NS_324.7	Stiff-man syndrome	Neurological
+NS_324.9	Chorea	Neurological
+NS_325	Abnormality of gait and mobility	Neurological
+NS_325.1	Abnormality of gait	Neurological
+NS_325.2	Difficulty walking	Neurological
+NS_325.3	Lack of coordination	Neurological
+NS_326	Demyelinating diseases of the central nervous system	Neurological
+NS_326.1	Multiple sclerosis	Neurological
+NS_326.2	Neuromyelitis optica	Neurological
+NS_326.3	Diffuse myelinoclastic sclerosis [Schilder's disease]	Neurological
+NS_328	Dementias and cerebral degeneration	Neurological
+NS_328.1	Dementias	Neurological
+NS_328.11	Alzheimer's disease	Neurological
+NS_328.12	Vascular dementia	Neurological
+NS_328.13	Frontotemporal dementia [FTD]	Neurological
+NS_328.14	Dementia with Lewy bodies	Neurological
+NS_328.3	Cerebral degeneration	Neurological
+NS_328.33	Corticobasal degeneration	Neurological
+NS_328.34	Reye's syndrome	Neurological
+NS_329	Symptoms and signs involving cognitive functions and awareness	Neurological
+NS_329.1	Memory loss	Neurological
+NS_329.2	Neurologic neglect syndrome	Neurological
+NS_329.3	Age-related cognitive decline	Neurological
+NS_329.4	Specified cognitive deficit	Neurological
+NS_329.41	Attention and concentration deficit	Neurological
+NS_329.42	Cognitive communication deficit	Neurological
+NS_329.43	Visuospatial deficit	Neurological
+NS_329.44	Psychomotor deficit	Neurological
+NS_329.45	Frontal lobe and executive function deficit	Neurological
+NS_329.5	Mild cognitive impairment	Neurological
+NS_329.6	Transient global amnesia	Neurological
+NS_329.8	"Altered mental status, unspecified"	Neurological
+NS_330	"Epilepsy, recurrent seizures, convulsions"	Neurological
+NS_330.1	Epilepsy	Neurological
+NS_330.11	Generalized epilepsy	Neurological
+NS_330.12	Partial epilepsy	Neurological
+NS_330.14	Lennox-Gastaut syndrome*	Neurological
+NS_330.15	Juvenile myoclonic epilepsy*	Neurological
+NS_330.3	Convulsions	Neurological
+NS_330.31	Febrile convulsions	Neurological
+NS_330.4	Post-traumatic seizures	Neurological
+NS_331	Headache	Neurological
+NS_331.1	Tension headache	Neurological
+NS_331.2	Post-traumatic headache	Neurological
+NS_331.3	"Headache syndromes, non migraine"	Neurological
+NS_331.31	"Persistent headache syndromes, non migraine"	Neurological
+NS_331.32	Hypnic headache	Neurological
+NS_331.33	Thunderclap headache	Neurological
+NS_331.4	Cluster headaches	Neurological
+NS_331.5	Paroxysmal hemicrania	Neurological
+NS_331.6	Migraine	Neurological
+NS_331.61	Migraine with aura	Neurological
+NS_331.62	Hemiplegic migraine	Neurological
+NS_331.63	Menstrual migraine	Neurological
+NS_331.64	Chronic migraine without aura	Neurological
+NS_331.7	Drug induced headache	Neurological
+NS_333	Sleep disorders	Neurological
+NS_333.1	Sleep apnea	Neurological
+NS_333.11	Obstructive sleep apnea	Neurological
+NS_333.12	Central sleep apnea	Neurological
+NS_333.13	High altitude periodic breathing	Neurological
+NS_333.14	Idiopathic sleep related nonobstructive alveolar hypoventilation	Neurological
+NS_333.2	Insomnia	Neurological
+NS_333.3	Hypersomnia	Neurological
+NS_333.4	Circadian rhythm sleep disorder	Neurological
+NS_333.5	Parasomnias	Neurological
+NS_333.51	Confusional arousals	Neurological
+NS_333.52	REM sleep behavior disorder	Neurological
+NS_333.53	Recurrent isolated sleep paralysis	Neurological
+NS_333.54	Sleepwalking [somnambulism]*	Neurological
+NS_333.55	Sleep terrors [night terrors]*	Neurological
+NS_333.6	Sleep related movement disorders	Neurological
+NS_333.61	Periodic limb movement disorder	Neurological
+NS_333.62	Sleep related leg cramps	Neurological
+NS_333.63	Sleep related bruxism	Neurological
+NS_333.64	Restless legs syndrome	Neurological
+NS_333.7	Narcolepsy	Neurological
+NS_333.71	Narcolepsy with cataplexy	Neurological
+NS_333.8	Sleep disturbances	Neurological
+NS_334	Disorders of facial and cranial nerves	Neurological
+NS_334.1	Trigeminal nerve disorders [CN5]	Neurological
+NS_334.11	Trigeminal neuralgia	Neurological
+NS_334.12	Atypical face pain	Neurological
+NS_334.2	Facial nerve disorders and weakness	Neurological
+NS_334.21	Bell's palsy	Neurological
+NS_334.22	Geniculate ganglionitis	Neurological
+NS_334.23	Facial weakness	Neurological
+NS_334.24	Clonic hemifacial spasm*	Neurological
+NS_334.25	Facial myokymia*	Neurological
+NS_334.3	Disorders of olfactory [1st] nerve	Neurological
+NS_334.4	Disorders of oculomotor nerves	Neurological
+NS_334.41	Third [oculomotor] nerve palsy	Neurological
+NS_334.42	Fourth [trochlear] nerve palsy	Neurological
+NS_334.44	Sixth [abducent] nerve palsy	Neurological
+NS_334.5	Other disorders of glossopharyngeal [9th] nerve	Neurological
+NS_334.6	Disorders of pneumogastric [10th] nerve	Neurological
+NS_334.8	Disorders of hypoglossal [12th] nerve	Neurological
+NS_334.9	Multiple cranial nerve palsies	Neurological
+NS_335	Nerve root and plexus disorders	Neurological
+NS_335.1	Nerve plexus lesions	Neurological
+NS_335.2	Nerve root lesions	Neurological
+NS_335.3	Neuralgic amyotrophy	Neurological
+NS_335.4	Phantom limb (syndrome)	Neurological
+NS_336	Mononeuropathies	Neurological
+NS_336.4	Mononeuritis of upper limb	Neurological
+NS_336.41	Carpal tunnel syndrome	Neurological
+NS_336.411	"Carpal tunnel syndrome, bilateral*"	Neurological
+NS_336.5	Mononeuritis of lower limb	Neurological
+NS_336.51	Lesion of sciatic nerve	Neurological
+NS_336.52	Meralgia paresthetica	Neurological
+NS_337	Polyneuropathies	Neurological
+NS_337.2	Inflammatory polyneuropathy	Neurological
+NS_337.21	Guillain-Barre syndrome [Acute infective polyneuritis]	Neurological
+NS_337.22	Chronic inflammatory demyelinating polyneuritis	Neurological
+NS_337.3	Toxic polyneuropathy	Neurological
+NS_337.4	Critical illness polyneuropathy	Neurological
+NS_337.5	Polyneuropathy related to infections	Neurological
+NS_337.6	Idiopathic progressive neuropathy	Neurological
+NS_338	Myasthenia gravis and other myoneural disorders	Neurological
+NS_338.1	Myasthenia gravis	Neurological
+NS_338.2	Toxic myoneural disorders	Neurological
+NS_338.3	Lambert-Eaton syndrome	Neurological
+NS_339	Primary disorders of muscles	Neurological
+NS_339.2	Myotonic disorders	Neurological
+NS_339.4	Periodic paralysis	Neurological
+NS_340	Myopathies	Neurological
+NS_340.1	Critical illness myopathy	Neurological
+NS_340.2	Toxic myopathy	Neurological
+NS_340.3	Inflammatory and immune myopathies	Neurological
+NS_341	Cerebral palsy and other paralytic syndromes	Neurological
+NS_341.1	Cerebral palsy	Neurological
+NS_341.11	Spastic cerebral palsy*	Neurological
+NS_341.12	Athetoid cerebral palsy	Neurological
+NS_341.13	Ataxic cerebral palsy*	Neurological
+NS_341.2	Hemiplegia and hemiparesis	Neurological
+NS_341.21	Flaccid hemiplegia	Neurological
+NS_341.22	Spastic hemiplegia	Neurological
+NS_341.23	Brown-Sequard syndrome*	Neurological
+NS_341.6	Cauda equina syndrome	Neurological
+NS_341.9	Transient paralysis	Neurological
+NS_342	Plegia and unspecified paralysis	Neurological
+NS_342.1	Paraplegia/Diplegia	Neurological
+NS_342.2	Quadriplegia	Neurological
+NS_342.4	Monoplegia	Neurological
+NS_343	Disorders of autonomic nervous system	Neurological
+NS_343.1	Peripheral autonomic neuropathy	Neurological
+NS_343.2	Autonomic dysreflexia	Neurological
+NS_343.3	Complex regional pain syndrome	Neurological
+NS_343.5	Horner's syndrome*	Neurological
+NS_343.6	Multi-system degeneration of the autonomic nervous system*	Neurological
+NS_343.7	Postural orthostatic tachycardia syndrome [POTS]*	Neurological
+NS_344	Disorders of the circulation of the cerebrospinal fluid	Neurological
+NS_344.1	Hydrocephalus	Neurological
+NS_344.11	Communicating hydrocephalus	Neurological
+NS_344.12	Obstructive hydrocephalus	Neurological
+NS_344.13	(Idiopathic) normal pressure hydrocephalus	Neurological
+NS_344.2	Benign intracranial hypertension	Neurological
+NS_344.3	Cerebrospinal fluid leak	Neurological
+NS_345	Encephalopathy	Neurological
+NS_345.1	Toxic encephalopathy	Neurological
+NS_345.2	Metabolic encephalopathy	Neurological
+NS_345.3	Hypertensive encephalopathy	Neurological
+NS_345.5	Posterior reversible encephalopathy syndrome*	Neurological
+NS_346	Brain damage and brain death	Neurological
+NS_346.1	Postconcussion syndrome	Neurological
+NS_346.2	Pseudobulbar affect	Neurological
+NS_346.3	Anoxic brain damage	Neurological
+NS_346.5	Compression of brain	Neurological
+NS_346.6	Cerebral edema	Neurological
+NS_347	Other disorders of the brain and CNS	Neurological
+NS_347.1	Cerebral cysts	Neurological
+NS_347.2	Disorders of meninges	Neurological
+NS_347.21	Dural tear	Neurological
+NS_347.3	Temporal sclerosis	Neurological
+NS_348	Other diseases of spinal cord	Neurological
+NS_348.1	Syringomyelia and syringobulbia	Neurological
+NS_348.2	Myelopathies	Neurological
+NS_348.21	Vascular myelopathies	Neurological
+NS_348.4	Spinal cord compression*	Neurological
+NS_349	Disorder of nervous system	Neurological
+NS_349.1	Abnormal findings on diagnostic test of central nervous system	Neurological
+NS_349.12	Abnormal electroencephalogram [EEG]	Neurological
+NS_349.13	Abnormal findings on diagnostic imaging of skull and head	Neurological
+NS_349.14	"White matter disease, unspecified*"	Neurological
+NS_349.15	Intracranial space-occupying lesion found on diagnostic imaging of central nervous system*	Neurological
+NS_349.2	Abnormal results of function studies of peripheral nervous system	Neurological
+NS_349.3	Nonspecific abnormal electromyogram [EMG]	Neurological
+NS_350	Other symptoms involving nervous  system	Neurological
+NS_350.2	Meningismus	Neurological
+NS_350.3	Abnormal reflex	Neurological
+NS_350.4	Abnormal posture	Neurological
+NS_350.5	Repeated falls*	Neurological
+NS_351	Disturbances of skin sensation	Neurological
+NS_351.1	Anesthesia of skin*	Neurological
+NS_351.2	Hypoesthesia of skin*	Neurological
+NS_351.3	Paresthesia of skin*	Neurological
+NS_351.4	Hyperesthesia*	Neurological
+NS_352	Disturbances of sensation of smell and taste	Neurological
+NS_352.1	Anosmia and Parosmia*	Neurological
+NS_352.2	Parageusia*	Neurological
+NS_354	Dizziness and giddiness	Neurological
+NS_355	Coma and other alteration of consciousness	Neurological
+NS_355.1	Coma	Neurological
+NS_355.2	Alteration of consciousness	Neurological
+NS_355.21	Transient alteration of awareness	Neurological
+NS_356	Speech disturbance	Neurological
+NS_356.1	Dysarthria	Neurological
+NS_356.2	Aphasia and dysphasia	Neurological
+NS_356.4	Slurred speech*	Neurological
+SO_360	Inflammation of eyelids	Sense organs
+SO_360.1	Hordeolum	Sense organs
+SO_360.2	Chalazion	Sense organs
+SO_360.4	Blepharitis	Sense organs
+SO_360.41	Ulcerative blepharitis	Sense organs
+SO_360.42	Squamous blepharitis	Sense organs
+SO_360.5	Noninfectious dermatoses of eyelid	Sense organs
+SO_360.51	Eczematous dermatitis of eyelid	Sense organs
+SO_360.52	Xeroderma of eyelid	Sense organs
+SO_360.53	Allergic dermatitis of eyelid	Sense organs
+SO_360.54	Discoid lupus erythematosus of eyelid	Sense organs
+SO_360.6	Abscess of eyelid	Sense organs
+SO_361	Disorders of eyelid function	Sense organs
+SO_361.1	Entropion and trichiasis of eyelid	Sense organs
+SO_361.12	Mechanical entropion	Sense organs
+SO_361.13	Spastic entropion	Sense organs
+SO_361.14	Cicatricial entropion	Sense organs
+SO_361.15	Trichiasis of eyelid without entropion	Sense organs
+SO_361.2	Lagophthalmos	Sense organs
+SO_361.22	Mechanical lagophthalmos	Sense organs
+SO_361.24	Cicatricial lagophthalmos	Sense organs
+SO_361.25	Paralytic lagophthalmos	Sense organs
+SO_361.3	Ptosis of eyelid	Sense organs
+SO_361.32	Mechanical ptosis of eyelid	Sense organs
+SO_361.33	Myogenic ptosis of eyelid	Sense organs
+SO_361.35	Paralytic ptosis	Sense organs
+SO_361.36	Brow ptosis*	Sense organs
+SO_361.4	Blepharochalasis	Sense organs
+SO_361.5	Eyelid retraction	Sense organs
+SO_361.6	Abnormal innervation syndrome of eyelid	Sense organs
+SO_361.8	Blepharophimosis	Sense organs
+SO_361.9	Ectropion of eyelid	Sense organs
+SO_361.92	Mechanical ectropion	Sense organs
+SO_361.93	Spastic ectropion	Sense organs
+SO_361.94	Cicatricial ectropion	Sense organs
+SO_362	Other disorders of the eyelids	Sense organs
+SO_362.1	Xanthelasma of eyelid	Sense organs
+SO_362.2	Hyperpigmentation of eyelid [Chloasma]	Sense organs
+SO_362.3	Hypertrichosis of eyelid	Sense organs
+SO_362.4	Hypotrichosis of eyelid [Madarosis]	Sense organs
+SO_362.5	Cysts of eyelid	Sense organs
+SO_362.6	Dermatochalasis of eyelid	Sense organs
+SO_362.7	Edema of eyelid	Sense organs
+SO_362.8	Meibomian gland dysfunction of eyelid*	Sense organs
+SO_363	Disorders of lacrimal system	Sense organs
+SO_363.1	Dacryoadenitis	Sense organs
+SO_363.2	Dry eye syndrome [Tear film insufficiency]	Sense organs
+SO_363.3	Lacrimal cysts	Sense organs
+SO_363.4	Lacrimal atrophy	Sense organs
+SO_363.5	Epiphora	Sense organs
+SO_363.51	Epiphora due to excess lacrimation	Sense organs
+SO_363.52	Epiphora due to insufficient drainage	Sense organs
+SO_363.6	Inflammation of lacrimal passages	Sense organs
+SO_363.61	Dacryocystitis	Sense organs
+SO_363.62	Canaliculitis	Sense organs
+SO_363.63	Lacrimal mucocele	Sense organs
+SO_363.7	Stenosis and insufficiency of lacrimal passages	Sense organs
+SO_365	Disorders of the orbit	Sense organs
+SO_365.1	Enophthalmos	Sense organs
+SO_365.2	Orbital edema or congestion	Sense organs
+SO_365.3	Exophthalmos [Proptosis]	Sense organs
+SO_365.4	Orbital cysts	Sense organs
+SO_365.5	Myopathy of extraocular muscles	Sense organs
+SO_365.6	Deformity of orbit	Sense organs
+SO_366	Disorders of conjunctiva	Sense organs
+SO_366.1	Pterygium of eye	Sense organs
+SO_366.2	Conjunctival degenerations and deposits	Sense organs
+SO_366.21	Pinguecula	Sense organs
+SO_366.3	Conjunctival scars	Sense organs
+SO_366.4	Vascular abnormalities of conjunctiva	Sense organs
+SO_366.42	Conjunctival hyperemia	Sense organs
+SO_366.5	Conjunctival edema	Sense organs
+SO_366.6	Conjunctival cysts	Sense organs
+SO_367	Inflammation of the eye	Sense organs
+SO_367.1	Conjunctivitis	Sense organs
+SO_367.11	Follicular conjunctivitis	Sense organs
+SO_367.12	Allergic conjunctivitis	Sense organs
+SO_367.13	Blepharoconjunctivitis	Sense organs
+SO_367.2	Keratitis	Sense organs
+SO_367.21	Corneal ulcer	Sense organs
+SO_367.22	Punctate keratitis	Sense organs
+SO_367.3	Keratoconjunctivitis	Sense organs
+SO_367.31	Keratoconjunctivitis sicca	Sense organs
+SO_367.32	Neurotrophic keratoconjunctivitis	Sense organs
+SO_367.4	Inflammation of orbit	Sense organs
+SO_367.41	Cellulitis of orbit	Sense organs
+SO_367.42	Granuloma of orbit	Sense organs
+SO_367.5	Uveitis	Sense organs
+SO_367.51	Panuveitis	Sense organs
+SO_367.52	Iridocyclitis	Sense organs
+SO_367.53	Chorioretinitis	Sense organs
+SO_367.56	Vogt-Koyanagi-Harada Disease	Sense organs
+SO_367.6	Episcleritis	Sense organs
+SO_367.7	Scleritis	Sense organs
+SO_367.8	Hypopyon	Sense organs
+SO_367.9	Chorioretinal inflammation	Sense organs
+SO_368	Disorders of sclera	Sense organs
+SO_368.1	Scleral staphyloma	Sense organs
+SO_368.2	Scleral ectasia	Sense organs
+SO_369	Disorders of the cornea	Sense organs
+SO_369.1	Corneal scars and opacities	Sense organs
+SO_369.11	Peripheral opacity of cornea	Sense organs
+SO_369.12	Central opacity of cornea	Sense organs
+SO_369.14	Corneal pigmentations	Sense organs
+SO_369.15	Corneal deposits	Sense organs
+SO_369.2	Corneal edema	Sense organs
+SO_369.3	Corneal neovascularization	Sense organs
+SO_369.4	Corneal degenerations	Sense organs
+SO_369.42	Recurrent erosion of cornea	Sense organs
+SO_369.43	Band keratopathy	Sense organs
+SO_369.44	Senile corneal changes including arcus senilis	Sense organs
+SO_369.6	Corneal deformities	Sense organs
+SO_369.61	Corneal ectasia	Sense organs
+SO_369.62	Keratoconus	Sense organs
+SO_369.7	Endothelial corneal dystrophy [Fuchs' dystrophy]	Sense organs
+SO_370	Disorders of iris and ciliary body	Sense organs
+SO_370.1	Degeneration of iris and ciliary body	Sense organs
+SO_370.11	Pigmentary iris degeneration	Sense organs
+SO_370.2	"Cyst of iris, ciliary body and anterior chamber"	Sense organs
+SO_370.3	Vascular disorders of iris and ciliary body	Sense organs
+SO_370.4	Adhesions and disruptions of iris and ciliary body	Sense organs
+SO_370.41	Pupillary abnormalities	Sense organs
+SO_370.6	Floppy iris syndrome	Sense organs
+SO_371	Cataract	Sense organs
+SO_371.1	Cortical age-related cataract	Sense organs
+SO_371.2	Subcapsular cataract	Sense organs
+SO_371.21	Anterior subcapsular polar cataract	Sense organs
+SO_371.22	Posterior subcapsular polar cataract	Sense organs
+SO_371.3	Nuclear cataract	Sense organs
+SO_371.4	"Cortical, lamellar, or zonular nonsenile cataract"	Sense organs
+SO_372	Disorders of lens (excluding cataracts)	Sense organs
+SO_372.1	Aphakia	Sense organs
+SO_372.2	Dislocation of lens	Sense organs
+SO_373	Disorders of choroid	Sense organs
+SO_373.1	Chorioretinal scars	Sense organs
+SO_373.2	Choroidal degenerations	Sense organs
+SO_373.5	Choroidal detachment	Sense organs
+SO_374	Disorders of the retina	Sense organs
+SO_374.1	Retinal detachments and breaks	Sense organs
+SO_374.11	Serous retinal detachment	Sense organs
+SO_374.12	Traction detachment of retina	Sense organs
+SO_374.13	Horseshoe tear of retina without detachment	Sense organs
+SO_374.14	Round hole of retina without detachment	Sense organs
+SO_374.2	Retinoschisis and retinal cysts	Sense organs
+SO_374.21	Retinoschisis	Sense organs
+SO_374.22	Retinal cysts	Sense organs
+SO_374.3	Retinal vasculopathy	Sense organs
+SO_374.32	Retinal microaneurysms	Sense organs
+SO_374.33	Retinal neovascularization	Sense organs
+SO_374.34	Retinal vasculitis	Sense organs
+SO_374.35	Retinal telangiectasis	Sense organs
+SO_374.36	Retinal ischemia	Sense organs
+SO_374.4	Retinopathy	Sense organs
+SO_374.41	Hypertensive retinopathy	Sense organs
+SO_374.42	Diabetic retinopathy	Sense organs
+SO_374.43	Exudative retinopathy	Sense organs
+SO_374.44	Central serous chorioretinopathy	Sense organs
+SO_374.5	Macular degeneration	Sense organs
+SO_374.51	Age-related macular degeneration	Sense organs
+SO_374.511	Nonexuadative (dry) age-related macular degeneration	Sense organs
+SO_374.512	Exuadative (wet) age-related macular degeneration	Sense organs
+SO_374.53	Cystoid macular degeneration	Sense organs
+SO_374.54	Drusen (degenerative) of macula	Sense organs
+SO_374.6	Peripheral retinal degeneration	Sense organs
+SO_374.61	Lattice degeneration of retina	Sense organs
+SO_374.7	Non-degenerative maculopathy	Sense organs
+SO_374.71	Puckering of macula	Sense organs
+SO_374.72	Toxic maculopathy of retina	Sense organs
+SO_374.73	Angioid streaks of macula	Sense organs
+SO_374.74	"Macular cyst, hole, or pseudohole"	Sense organs
+SO_374.8	Retinal edema	Sense organs
+SO_374.9	Retinal occlusions	Sense organs
+SO_374.91	Transient retinal arterial occlusion [Amaurosis fugax]	Sense organs
+SO_375	Abnormal intraocular pressure	Sense organs
+SO_375.1	Glaucoma	Sense organs
+SO_375.11	Open angle glaucoma	Sense organs
+SO_375.111	Capsular glaucoma with pseudoexfoliation of lens	Sense organs
+SO_375.112	Pigmentary glaucoma	Sense organs
+SO_375.113	Low-tension glaucoma	Sense organs
+SO_375.12	Angle-Closure Glaucoma	Sense organs
+SO_375.6	Ocular hypertension	Sense organs
+SO_375.61	Blind hypertensive eye	Sense organs
+SO_375.7	Hypotony of eye	Sense organs
+SO_376	Disorders of vitreous body	Sense organs
+SO_376.1	Vitreous degeneration	Sense organs
+SO_376.2	Vitreous opacities	Sense organs
+SO_376.21	Crystalline deposits in vitreous body	Sense organs
+SO_376.22	Vitreous membranes and strands	Sense organs
+SO_376.3	Vitreous prolapse	Sense organs
+SO_376.4	Vitreomacular adhesion	Sense organs
+SO_377	Hemorrhage of the eye	Sense organs
+SO_377.1	Hemorrhage of orbit	Sense organs
+SO_377.2	Conjunctival hemorrhage	Sense organs
+SO_377.3	Choroidal hemorrhage and rupture	Sense organs
+SO_377.4	Retinal hemorrhage	Sense organs
+SO_377.5	Vitreous hemorrhage	Sense organs
+SO_377.6	Hemorrhage in optic nerve sheath	Sense organs
+SO_377.7	Hemophthalmos	Sense organs
+SO_377.8	Hyphema	Sense organs
+SO_379	Infection of the eye	Sense organs
+SO_379.2	"Eye infection, viral"	Sense organs
+SO_379.3	"Eye infection, toxoplasmosis"	Sense organs
+SO_380	Disorders of optic nerve and visual pathways	Sense organs
+SO_380.1	Optic neuropathy	Sense organs
+SO_380.11	Optic neuritis	Sense organs
+SO_380.12	Ischemic optic neuropathy	Sense organs
+SO_380.2	Disorders of optic disc	Sense organs
+SO_380.21	Papilledema	Sense organs
+SO_380.22	Optic disc drusen	Sense organs
+SO_380.23	Optic nerve hypoplasia	Sense organs
+SO_380.24	Pseudopapilledema of optic disc	Sense organs
+SO_380.3	Optic atrophy	Sense organs
+SO_380.5	Disorders of visual cortex	Sense organs
+SO_380.51	Cortical blindness	Sense organs
+SO_381	Strabismus	Sense organs
+SO_381.1	Paralytic strabismus [Neurogenic strabismus]	Sense organs
+SO_381.11	Ophthalmoplegia	Sense organs
+SO_381.3	Esotropia	Sense organs
+SO_381.31	Alternating esotropia	Sense organs
+SO_381.32	Accommodative esotropia	Sense organs
+SO_381.4	Exotropia	Sense organs
+SO_381.41	Alternating exotropia	Sense organs
+SO_381.5	Vertical strabismus	Sense organs
+SO_381.6	Duane's syndrome [Duane anomaly]	Sense organs
+SO_381.7	Cyclotropia	Sense organs
+SO_381.8	Heterophoria	Sense organs
+SO_381.81	Esophoria	Sense organs
+SO_381.82	Exophoria	Sense organs
+SO_381.83	Cyclophoria	Sense organs
+SO_382	Other disorders of binocular movement	Sense organs
+SO_382.1	Impaired convergence	Sense organs
+SO_382.2	Palsy of conjugate gaze	Sense organs
+SO_383	Irregular eye movements	Sense organs
+SO_383.1	Nystagmus	Sense organs
+SO_383.2	Saccadic eye movements	Sense organs
+SO_384	Anomalies of pupillary function	Sense organs
+SO_384.1	Anisocoria	Sense organs
+SO_384.2	Miosis	Sense organs
+SO_384.3	Mydriasis	Sense organs
+SO_384.4	Tonic pupil	Sense organs
+SO_385	Abnormal results of function studies of eye	Sense organs
+SO_386	Visual disturbances	Sense organs
+SO_386.1	Amblyopia	Sense organs
+SO_386.2	Diplopia	Sense organs
+SO_386.3	Visual discomfort	Sense organs
+SO_386.4	Visual field defects	Sense organs
+SO_386.41	Scotoma	Sense organs
+SO_386.42	Hemianopia	Sense organs
+SO_386.43	Constriction of visual field	Sense organs
+SO_386.5	Color vision deficiencies	Sense organs
+SO_386.6	Night blindness	Sense organs
+SO_386.7	Impaired contrast sensitivity*	Sense organs
+SO_386.8	Sudden or transient visual loss	Sense organs
+SO_386.9	Visual distortions and subjective visual disturbances	Sense organs
+SO_387	Disorders of refraction and accommodation	Sense organs
+SO_387.1	Hypermetropia	Sense organs
+SO_387.2	Myopia	Sense organs
+SO_387.21	Progressive high (degenerative) myopia	Sense organs
+SO_387.3	Astigmatism	Sense organs
+SO_387.4	Presbyopia	Sense organs
+SO_387.5	Anisometropia	Sense organs
+SO_387.6	Aniseikonia	Sense organs
+SO_387.8	Disorders of accommodation	Sense organs
+SO_388	Blindness and low vision	Sense organs
+SO_389	Other disorders of eye	Sense organs
+SO_389.1	Ocular pain	Sense organs
+SO_389.2	Leucocoria	Sense organs
+SO_390	Disorders of external ear	Sense organs
+SO_390.1	Otitis externa	Sense organs
+SO_390.2	Exostosis of external auditory canal	Sense organs
+SO_390.4	Impacted cerumen	Sense organs
+SO_390.5	Stenosis of external ear canal	Sense organs
+SO_390.6	Perichondritis and chondritis of pinna	Sense organs
+SO_391	Disorders of the middle ear	Sense organs
+SO_391.1	Otitis media	Sense organs
+SO_391.2	Eustachian tube disorders	Sense organs
+SO_391.21	Eustachian salpingitis	Sense organs
+SO_391.22	Obstruction of Eustachian tube	Sense organs
+SO_391.23	Patulous Eustachian tube	Sense organs
+SO_391.3	Adhesive middle ear disease [Glue ear]	Sense organs
+SO_391.4	Tympanosclerosis	Sense organs
+SO_391.5	Abnormalities of ear ossicles	Sense organs
+SO_391.6	Cholesteatoma of middle ear	Sense organs
+SO_391.7	Perforation of tympanic membrane	Sense organs
+SO_391.8	Otosclerosis	Sense organs
+SO_391.9	Myringitis	Sense organs
+SO_392	Otalgia and effusion of ear	Sense organs
+SO_392.1	Otalgia [ear pain]	Sense organs
+SO_392.2	Otorrhea	Sense organs
+SO_393	Mastoiditis and related conditions	Sense organs
+SO_394	Disorders of vestibular function	Sense organs
+SO_394.1	Meniere's disease	Sense organs
+SO_394.2	Vertigo	Sense organs
+SO_394.21	Paroxysmal vertigo	Sense organs
+SO_394.22	Vestibular neuronitis	Sense organs
+SO_394.23	Central origin vertigo	Sense organs
+SO_394.4	Abnormal vestibular function study	Sense organs
+SO_395	Other diseases of inner ear	Sense organs
+SO_395.1	Labyrinthitis	Sense organs
+SO_395.2	Labyrinthine fistula	Sense organs
+SO_396	Hearing impairment	Sense organs
+SO_396.1	Conductive hearing loss	Sense organs
+SO_396.2	Sensorineural hearing loss	Sense organs
+SO_396.3	Mixed conductive and sensorineural hearing loss	Sense organs
+SO_396.4	Ototoxic hearing loss*	Sense organs
+SO_396.5	Sudden idiopathic hearing loss	Sense organs
+SO_396.6	Transient ischemic deafness	Sense organs
+SO_396.7	"Deaf nonspeaking, not elsewhere classified"	Sense organs
+SO_396.8	Bilateral hearing loss	Sense organs
+SO_396.9	Unilateral hearing loss	Sense organs
+SO_397	Other hearing abnormality	Sense organs
+SO_397.1	Tinnitus	Sense organs
+SO_397.11	Pulsatile tinnitus*	Sense organs
+SO_397.2	Noise effects on inner ear	Sense organs
+SO_397.3	Hyperacusis	Sense organs
+SO_398	Other disorders of ear	Sense organs
+SO_399	Abnormal auditory function study	Sense organs
+CV_400	Rheumatic fever and chronic rheumatic heart diseases	Cardiovascular
+CV_400.1	Rheumatic chorea	Cardiovascular
+CV_400.2	Rheumatic heart disease	Cardiovascular
+CV_401	Hypertension	Cardiovascular
+CV_401.1	Essential hypertension	Cardiovascular
+CV_401.2	Hypertensive heart disease	Cardiovascular
+CV_401.6	Secondary hypertension	Cardiovascular
+CV_401.61	Renovascular hypertension	Cardiovascular
+CV_401.7	Hypertensive crisis*	Cardiovascular
+CV_402	Elevated blood pressure reading without diagnosis of hypertension	Cardiovascular
+CV_403	Angina pectoris	Cardiovascular
+CV_403.1	Coronary artery spasm [Coronary vasospasm]*	Cardiovascular
+CV_404	Ischemic heart disease	Cardiovascular
+CV_404.1	Myocardial infarction [Heart attack]	Cardiovascular
+CV_404.11	Acute myocardial infarction	Cardiovascular
+CV_404.2	Coronary atherosclerosis [Atherosclerotic heart disease]	Cardiovascular
+CV_404.22	Coronary atherosclerosis due to lipid rich plaque	Cardiovascular
+CV_404.23	Coronary atherosclerosis due to calcified coronary lesion	Cardiovascular
+CV_406	Pulmonary heart disease	Cardiovascular
+CV_406.1	Pulmonary hypertension	Cardiovascular
+CV_406.11	Primary pulmonary hypertension	Cardiovascular
+CV_406.12	Kyphoscoliotic heart disease	Cardiovascular
+CV_406.16	Group 4 pulmonary hypertension*	Cardiovascular
+CV_406.2	Acute pulmonary heart disease	Cardiovascular
+CV_408	Diseases of pulmonary vessels	Cardiovascular
+CV_410	Inflammation of the heart [Carditis]	Cardiovascular
+CV_410.1	Pericarditis	Cardiovascular
+CV_410.2	Endocarditis	Cardiovascular
+CV_410.3	Myocarditis	Cardiovascular
+CV_411	Other diseases of pericardium	Cardiovascular
+CV_411.1	Hemopericardium NEC	Cardiovascular
+CV_411.2	Pericardial effusion (noninflammatory)*	Cardiovascular
+CV_411.3	Cardiac tamponade	Cardiovascular
+CV_413	Heart valve disorders	Cardiovascular
+CV_413.1	Mitral valve disorders	Cardiovascular
+CV_413.11	Mitral valve insufficiency	Cardiovascular
+CV_413.12	Mitral valve prolapse*	Cardiovascular
+CV_413.13	Mitral valve stenosis	Cardiovascular
+CV_413.2	Aortic valve disorders	Cardiovascular
+CV_413.21	Aortic stenosis	Cardiovascular
+CV_413.22	Aortic insufficiency	Cardiovascular
+CV_413.3	Tricuspid valve disorders	Cardiovascular
+CV_413.31	Tricuspid value stenosis*	Cardiovascular
+CV_413.32	Tricuspid value insufficiency*	Cardiovascular
+CV_413.4	Pulmonary valve disorders	Cardiovascular
+CV_413.41	Pulmonary valve stenosis	Cardiovascular
+CV_413.42	Pulmonary valve insufficiency*	Cardiovascular
+CV_413.6	Heart valve replaced	Cardiovascular
+CV_414	Cardiomyopathy	Cardiovascular
+CV_414.1	Hypertrophic cardiomyopathy	Cardiovascular
+CV_414.11	Hypertrophic obstructive cardiomyopathy	Cardiovascular
+CV_414.2	Dilated cardiomyopathy*	Cardiovascular
+CV_414.3	Alcoholic cardiomyopathy	Cardiovascular
+CV_414.5	Ischemic cardiomyopathy*	Cardiovascular
+CV_414.6	Endomyocardial (eosinophilic) disease [Endomyocardial fibrosis]	Cardiovascular
+CV_414.7	Endocardial fibroelastosis	Cardiovascular
+CV_414.8	Restrictive cardiomyopathy*	Cardiovascular
+CV_414.9	Takotsubo syndrome [Stress cardiomyopathy]	Cardiovascular
+CV_416	Cardiac arrhythmia and conduction disorders	Cardiovascular
+CV_416.1	Paroxysmal tachycardia	Cardiovascular
+CV_416.11	Supraventricular tachycardia	Cardiovascular
+CV_416.12	Ventricular tachycardia	Cardiovascular
+CV_416.121	Torsades de pointes*	Cardiovascular
+CV_416.2	Atrial fibrillation and flutter	Cardiovascular
+CV_416.21	Atrial fibrillation	Cardiovascular
+CV_416.211	Paroxysmal atrial fibrillation*	Cardiovascular
+CV_416.212	Persistent atrial fibrillation*	Cardiovascular
+CV_416.213	Chronic atrial fibrillation*	Cardiovascular
+CV_416.214	Permanent atrial fibrillation*	Cardiovascular
+CV_416.22	Atrial flutter	Cardiovascular
+CV_416.221	Typical atrial flutter*	Cardiovascular
+CV_416.222	Atypical atrial flutter*	Cardiovascular
+CV_416.3	Ventricular fibrillation and flutter	Cardiovascular
+CV_416.31	Ventricular fibrillation	Cardiovascular
+CV_416.32	Ventricular flutter	Cardiovascular
+CV_416.4	Heart block	Cardiovascular
+CV_416.41	Atrioventricular block	Cardiovascular
+CV_416.411	"Atrioventricular block, first degree"	Cardiovascular
+CV_416.412	"Atrioventricular block, second degree"	Cardiovascular
+CV_416.413	"Atrioventricular block, complete"	Cardiovascular
+CV_416.42	Left bundle branch block	Cardiovascular
+CV_416.43	Right bundle branch block	Cardiovascular
+CV_416.5	Premature depolarization [Premature beats]	Cardiovascular
+CV_416.51	Atrial premature depolarization [Supraventricular premature beats]	Cardiovascular
+CV_416.52	Ventricular premature depolarization*	Cardiovascular
+CV_416.6	Long QT syndrome	Cardiovascular
+CV_416.7	Sinoatrial node dysfunction	Cardiovascular
+CV_416.71	Sick sinus syndrome*	Cardiovascular
+CV_416.8	Pre-excitation syndrome [Anomalous atrioventricular excitation]	Cardiovascular
+CV_417	Abnormalities of heart beat	Cardiovascular
+CV_417.1	Palpitations	Cardiovascular
+CV_417.2	Tachycardia	Cardiovascular
+CV_417.3	Bradycardia	Cardiovascular
+CV_418	Abnormal results of cardiovascular function studies	Cardiovascular
+CV_418.1	Abnormal electrocardiogram [ECG] [EKG]	Cardiovascular
+CV_418.2	Abnormal findings on diagnostic imaging of heart and coronary circulation*	Cardiovascular
+CV_419	Presence of cardiac device	Cardiovascular
+CV_419.1	Presence of cardiac pacemaker	Cardiovascular
+CV_419.2	Presence of cardiac defibrillator	Cardiovascular
+CV_420	Cardiac arrest	Cardiovascular
+CV_423	Abnormal cardiac sounds	Cardiovascular
+CV_423.1	Cardiac murmurs	Cardiovascular
+CV_424	Heart failure	Cardiovascular
+CV_424.1	Left heart failure	Cardiovascular
+CV_424.2	Systolic heart failure	Cardiovascular
+CV_424.3	Diastolic heart failure	Cardiovascular
+CV_424.4	Combined systolic and diastolic heart failure	Cardiovascular
+CV_424.5	Right heart failure*	Cardiovascular
+CV_424.7	Rheumatic heart failure	Cardiovascular
+CV_425	Cardiomegaly	Cardiovascular
+CV_426	Complications and ill-defined descriptions of heart disease	Cardiovascular
+CV_430	Nontraumatic Intracranial hemorrhage	Cardiovascular
+CV_430.1	Nontraumatic subarachnoid hemorrhage	Cardiovascular
+CV_430.2	Nontraumatic intracerebral hemorrhage	Cardiovascular
+CV_430.3	Nontraumatic subdural hemorrhage	Cardiovascular
+CV_430.4	Nontraumatic extradural hemorrhage	Cardiovascular
+CV_431	Stroke and transient cerebral ischemic attacks	Cardiovascular
+CV_431.1	Stroke	Cardiovascular
+CV_431.11	Cerebral infarction [Ischemic stroke]	Cardiovascular
+CV_431.12	Hemorrhagic stroke	Cardiovascular
+CV_431.13	Brain stem stroke syndrome*	Cardiovascular
+CV_431.14	Cerebellar stroke syndrome*	Cardiovascular
+CV_431.15	Lacunar syndrome*	Cardiovascular
+CV_431.2	Transient cerebral ischemic attack [TIA]	Cardiovascular
+CV_433	Other cerebrovascular disease	Cardiovascular
+CV_433.1	Occlusion and stenosis of cerebral arteries	Cardiovascular
+CV_433.2	Occlusion and stenosis of precerebral arteries	Cardiovascular
+CV_433.21	Carotid artery stenosis	Cardiovascular
+CV_433.3	Cerebrovascular insufficiency	Cardiovascular
+CV_433.31	Cerebrovascular vasospasm and vasoconstriction*	Cardiovascular
+CV_433.32	Vertebro-basilar artery syndrome	Cardiovascular
+CV_433.34	"Cerebral artery syndrome (middle, anterior, posterior)*"	Cardiovascular
+CV_433.4	Moyamoya disease	Cardiovascular
+CV_436	Atherosclerosis [ASCVD]	Cardiovascular
+CV_436.1	Atherosclerosis of renal artery	Cardiovascular
+CV_436.2	Atherosclerosis of the extremities	Cardiovascular
+CV_436.23	Chronic total occlusion of artery of the extremities	Cardiovascular
+CV_436.3	Atherosclerosis of aorta	Cardiovascular
+CV_436.4	Atheroembolism	Cardiovascular
+CV_436.5	Cerebral atherosclerosis	Cardiovascular
+CV_438	Aneurysm or ectasia	Cardiovascular
+CV_438.1	Aortic aneurysm and ectasia	Cardiovascular
+CV_438.11	Abdominal aortic aneurysm	Cardiovascular
+CV_438.12	Thoracic aneurysm	Cardiovascular
+CV_438.13	Thoracoabdominal aortic aneurysm	Cardiovascular
+CV_438.14	Ruptured aortic aneurysm	Cardiovascular
+CV_438.2	Aneurysm of iliac or artery of lower extremity	Cardiovascular
+CV_438.3	Aneurysm of carotid artery	Cardiovascular
+CV_438.4	Arterial dissection	Cardiovascular
+CV_438.41	Aortic dissection	Cardiovascular
+CV_438.42	Carotid artery dissection	Cardiovascular
+CV_438.43	Coronary artery dissection	Cardiovascular
+CV_438.5	Coronary artery aneurysm	Cardiovascular
+CV_438.6	Cerebral aneurysm	Cardiovascular
+CV_438.7	Aneurysm of heart	Cardiovascular
+CV_438.8	Rupture of artery	Cardiovascular
+CV_438.9	Aneurysm of pulmonary artery	Cardiovascular
+CV_439	Hemorrhoids	Cardiovascular
+CV_440	Embolism and thrombosis	Cardiovascular
+CV_440.1	Venous thromboembolism	Cardiovascular
+CV_440.11	Deep vein thrombosis [DVT]	Cardiovascular
+CV_440.12	Portal vein thrombosis	Cardiovascular
+CV_440.13	Phlebitis and thrombophlebitis	Cardiovascular
+CV_440.14	Budd-Chiari syndrome	Cardiovascular
+CV_440.15	Cerebral venous sinus thrombosis	Cardiovascular
+CV_440.2	Arterial embolism and thrombosis	Cardiovascular
+CV_440.21	Embolism of cerebral or precerebral arteries	Cardiovascular
+CV_440.22	Thrombosis of cerebral or precerebral arteries	Cardiovascular
+CV_440.3	Pulmonary embolism	Cardiovascular
+CV_440.4	Septic embolism	Cardiovascular
+CV_441	Arteriovenous malformation	Cardiovascular
+CV_441.1	Arteriovenous fistula	Cardiovascular
+CV_441.2	Pulmonary arteriovenous malformation	Cardiovascular
+CV_441.3	Arteriovenous malformation of digestive system*	Cardiovascular
+CV_441.4	Arteriovenous malformation of renal vessel*	Cardiovascular
+CV_441.5	Arteriovenous malformation of precerebral or cerebral vessels*	Cardiovascular
+CV_442	Disease of capillaries	Cardiovascular
+CV_443	Other disorders of arteries and arterioles	Cardiovascular
+CV_443.1	Stricture of artery [Arterial stenosis]	Cardiovascular
+CV_443.2	Celiac artery compression syndrome	Cardiovascular
+CV_443.3	Arterial fibromuscular dysplasia*	Cardiovascular
+CV_443.4	Necrosis of artery	Cardiovascular
+CV_444	Venous insufficiency	Cardiovascular
+CV_444.1	Varicose veins	Cardiovascular
+CV_444.11	Varicose veins of lower extremities	Cardiovascular
+CV_444.12	Gastric varices*	Cardiovascular
+CV_444.13	Esophageal varices	Cardiovascular
+CV_444.14	Vulval varices	Cardiovascular
+CV_444.15	Scrotal varices [Varicocele]	Cardiovascular
+CV_444.5	Venous insufficiency (chronic) (peripheral)	Cardiovascular
+CV_444.6	Chronic venous hypertension	Cardiovascular
+CV_446	Hypotension	Cardiovascular
+CV_446.2	Orthostatic hypotension	Cardiovascular
+CV_447	Nonspecific low blood-pressure reading	Cardiovascular
+CV_448	Peripheral vascular disease	Cardiovascular
+CV_448.1	Raynaud's syndrome	Cardiovascular
+CV_448.2	Erythromelalgia	Cardiovascular
+CV_448.9	Peripheral vascular disease NOS [includes PAD]	Cardiovascular
+CV_449	Other disorders of the circulatory system	Cardiovascular
+CV_452	"Hemorrhage, NOS"	Cardiovascular
+RE_460	Respiratory infection	Respiratory
+RE_460.1	Acute upper respiratory infection	Respiratory
+RE_460.2	Acute lower respiratory infection	Respiratory
+RE_460.3	Pulmonary tuberculosis	Respiratory
+RE_462	Sinusitis	Respiratory
+RE_462.1	Acute sinusitis	Respiratory
+RE_462.2	Chronic sinusitis	Respiratory
+RE_463	Rhinitis and nasal congestion	Respiratory
+RE_463.1	Chronic rhinitis	Respiratory
+RE_463.2	Allergic rhinitis	Respiratory
+RE_463.21	Seasonal allergic rhinitis	Respiratory
+RE_463.22	Allergic rhinitis due to food	Respiratory
+RE_463.23	"Allergic rhinitis, due to animal hair and dander"	Respiratory
+RE_463.3	Vasomotor rhinitis*	Respiratory
+RE_463.4	Nasal congestion*	Respiratory
+RE_463.5	Postnasal drip	Respiratory
+RE_464	Nasopharyngitis	Respiratory
+RE_464.1	Acute nasopharyngitis	Respiratory
+RE_464.2	Chronic nasopharyngitis	Respiratory
+RE_465	Pharyngitis	Respiratory
+RE_465.1	Acute Pharyngitis	Respiratory
+RE_465.11	Streptococcal tonsillitis/pharyngitis	Respiratory
+RE_465.2	Chronic Pharyngitis	Respiratory
+RE_465.3	Pharyngeal abscess	Respiratory
+RE_466	Tonsillitis and adenoiditis	Respiratory
+RE_466.1	Acute tonsillitis and adenoiditis	Respiratory
+RE_466.2	Chronic tonsillitis and adenoiditis	Respiratory
+RE_466.3	Peritonsillar abscess	Respiratory
+RE_466.4	Hypertrophy of tonsils and adenoids	Respiratory
+RE_467	Laryngitis and tracheitis	Respiratory
+RE_467.1	Acute laryngitis and tracheitis	Respiratory
+RE_467.11	Acute obstructive laryngitis [croup]	Respiratory
+RE_467.2	Chronic laryngitis and laryngotracheitis	Respiratory
+RE_467.3	Supraglottitis	Respiratory
+RE_467.4	Acute epiglottitis	Respiratory
+RE_468	Pneumonia	Respiratory
+RE_468.1	Viral pneumonia	Respiratory
+RE_468.2	Bacterial pneumonia	Respiratory
+RE_468.21	Pneumonia due to Streptococcus pneumoniae	Respiratory
+RE_468.22	Pneumonia due to Pseudomonas	Respiratory
+RE_468.3	Ventilator associated pneumonia	Respiratory
+RE_468.4	Personal history of pneumonia (recurrent)	Respiratory
+RE_468.5	Pneumonia due to fungus	Respiratory
+RE_468.6	Cytomegaloviral pneumonitis	Respiratory
+RE_468.8	Bronchopneumonia	Respiratory
+RE_468.9	Lobar pneumonia*	Respiratory
+RE_469	Bronchitis	Respiratory
+RE_469.1	Acute bronchitis	Respiratory
+RE_469.2	Chronic bronchitis	Respiratory
+RE_470	Acute bronchiolitis	Respiratory
+RE_471	Other disorders of nose and nasal sinuses	Respiratory
+RE_471.1	Cyst and mucocele of nose and nasal sinus*	Respiratory
+RE_471.2	Deviated nasal septum	Respiratory
+RE_471.3	Hypertrophy of nasal turbinates	Respiratory
+RE_471.5	Nasal polyps	Respiratory
+RE_472	"Diseases of vocal cords and larynx, not elsewhere classified"	Respiratory
+RE_472.1	Paralysis of vocal cords and larynx	Respiratory
+RE_472.2	Polyp of vocal cord and larynx	Respiratory
+RE_472.3	Edema of larynx	Respiratory
+RE_472.4	Laryngeal spasm	Respiratory
+RE_472.5	Stenosis of larynx	Respiratory
+RE_472.6	Nodules of vocal cords*	Respiratory
+RE_474	Chronic obstructive pulmonary disease [COPD]	Respiratory
+RE_474.1	Emphysema	Respiratory
+RE_474.11	Unilateral pulmonary emphysema [MacLeod's syndrome]*	Respiratory
+RE_474.12	Panlobular emphysema*	Respiratory
+RE_474.13	Centrilobular emphysema*	Respiratory
+RE_475	Asthma	Respiratory
+RE_475.5	Exercise induced bronchospasm	Respiratory
+RE_475.6	Cough variant asthma	Respiratory
+RE_475.7	Allergic bronchopulmonary aspergillosis	Respiratory
+RE_476	Bronchiectasis	Respiratory
+RE_477	Inhalation lung injury	Respiratory
+RE_477.1	Pneumoconiosis	Respiratory
+RE_477.2	Hypersensitivity pneumonitis	Respiratory
+RE_477.3	Vaping-related disorder*	Respiratory
+RE_478	Aspiration pneumonia	Respiratory
+RE_479	Pulmonary insufficiency and acute respiratory distress syndrome	Respiratory
+RE_479.1	Acute respiratory distress syndrome [ARDS]*	Respiratory
+RE_479.3	Respiratory failure	Respiratory
+RE_479.31	Acute respiratory failure	Respiratory
+RE_479.32	Chronic respiratory failure	Respiratory
+RE_479.6	Pulmonary collapse [Atelectasis]	Respiratory
+RE_480	Pulmonary edema	Respiratory
+RE_480.1	Acute pulmonary edema	Respiratory
+RE_480.2	Chronic pulmonary edema	Respiratory
+RE_481	Interstitial pulmonary diseases	Respiratory
+RE_481.1	Pulmonary eosinophilia	Respiratory
+RE_481.2	Alveolar proteinosis	Respiratory
+RE_481.3	Pulmonary alveolar microlithiasis	Respiratory
+RE_481.4	Pulmonary fibrosis	Respiratory
+RE_481.41	Idiopathic interstitial pneumonia	Respiratory
+RE_481.42	Idiopathic pulmonary fibrosis	Respiratory
+RE_481.43	Interstitial pneumonitis	Respiratory
+RE_481.44	Respiratory bronchiolitis interstitial lung disease [RBILD]	Respiratory
+RE_481.45	Cryptogenic organizing pneumonia	Respiratory
+RE_481.46	Desquamative interstitial pneumonia	Respiratory
+RE_481.5	Lymphangioleiomyomatosis	Respiratory
+RE_481.6	Lymphoid interstitial pneumonia	Respiratory
+RE_481.7	Idiopathic pulmonary hemosiderosis	Respiratory
+RE_482	Suppurative and necrotic conditions of the lower respiratory tract	Respiratory
+RE_482.1	Abscess of lung and mediastinum	Respiratory
+RE_482.2	Pyothorax (empyema)	Respiratory
+RE_483	Pleural effusion	Respiratory
+RE_484	Pneumothorax and air leak	Respiratory
+RE_484.1	Spontaneous pneumothorax	Respiratory
+RE_484.2	Chronic pneumothorax	Respiratory
+RE_484.3	Iatrogenic pneumothorax	Respiratory
+RE_484.4	Interstitial emphysema [Pneumomediastinum]	Respiratory
+RE_486	Other respiratory disorders	Respiratory
+RE_486.3	Mediastinitis	Respiratory
+RE_486.5	Acute chest syndrome	Respiratory
+RE_486.7	Compensatory emphysema	Respiratory
+RE_487	Hemorrhage from respiratory passages	Respiratory
+RE_487.1	Epistaxis	Respiratory
+RE_487.2	Hemorrhage from throat	Respiratory
+RE_487.3	Hemoptysis	Respiratory
+RE_488	Abnormalities of breathing	Respiratory
+RE_488.1	Dyspnea [Shortness of breath]	Respiratory
+RE_488.11	Orthopnea	Respiratory
+RE_488.2	Hyperventilation	Respiratory
+RE_488.3	Periodic breathing [Cheyne-Stokes]	Respiratory
+RE_488.4	Tachypnea	Respiratory
+RE_488.5	Stridor	Respiratory
+RE_488.6	Wheezing	Respiratory
+RE_488.7	Apnea	Respiratory
+RE_488.8	Obesity hypoventilation syndrome [OHS]	Respiratory
+RE_488.9	Snoring*	Respiratory
+RE_489	Disorders of diaphragm	Respiratory
+RE_489.1	Hiccough	Respiratory
+RE_491	Pleurisy	Respiratory
+RE_492	Tracheoesophageal fistula	Respiratory
+RE_494	Voice disturbance	Respiratory
+RE_494.1	Dysphonia	Respiratory
+RE_494.2	Aphonia	Respiratory
+RE_494.3	Hypernasality	Respiratory
+RE_494.4	Hyponasality	Respiratory
+RE_495	Abnormal findings on diagnostic imaging of lung	Respiratory
+RE_495.1	Solitary pulmonary nodule	Respiratory
+RE_496	Abnormal results of pulmonary function studies	Respiratory
+RE_497	Respiratory arrest	Respiratory
+RE_498	Asphyxia and hypoxemia	Respiratory
+RE_498.1	Hypoxemia	Respiratory
+RE_498.2	Cyanosis	Respiratory
+RE_499	Other symptoms and disorders of the respiratory system	Respiratory
+RE_499.1	Cough	Respiratory
+RE_499.11	Acute cough*	Respiratory
+RE_499.12	Chronic cough*	Respiratory
+RE_499.2	Abnormal sputum	Respiratory
+RE_499.3	Bronchospasm	Respiratory
+RE_499.4	Throat pain	Respiratory
+GI_500	Disorders of tooth develoment	Gastrointestinal
+GI_500.1	Anodontia	Gastrointestinal
+GI_500.2	Abnormalities of size and form of teeth	Gastrointestinal
+GI_500.3	Supernumerary teeth	Gastrointestinal
+GI_500.4	Disturbances in tooth eruption	Gastrointestinal
+GI_500.41	Impacted teeth*	Gastrointestinal
+GI_500.6	Ankylosis of teeth	Gastrointestinal
+GI_502	Diseases of teeth and supporting structures	Gastrointestinal
+GI_502.1	Diseases of hard tissues of teeth	Gastrointestinal
+GI_502.11	Dental caries	Gastrointestinal
+GI_502.12	Dental abrasion and erosion	Gastrointestinal
+GI_502.13	Cracked tooth	Gastrointestinal
+GI_502.14	Deposits [accretions] on teeth	Gastrointestinal
+GI_502.15	Pathological resorption of teeth	Gastrointestinal
+GI_502.16	Loss of teeth and edentulism	Gastrointestinal
+GI_502.17	Hypercementosis	Gastrointestinal
+GI_502.2	Atrophy of edentulous alveolar ridge	Gastrointestinal
+GI_502.3	Diseases of pulp and periapical tissues	Gastrointestinal
+GI_502.31	Pulpitis	Gastrointestinal
+GI_502.32	Periapical abscess	Gastrointestinal
+GI_504	Periodontal diseases	Gastrointestinal
+GI_504.1	Gingivitis	Gastrointestinal
+GI_504.2	Gingival recession	Gastrointestinal
+GI_504.3	Periodontitis	Gastrointestinal
+GI_504.31	Aggressive periodontitis	Gastrointestinal
+GI_504.4	Gingival enlargement*	Gastrointestinal
+GI_505	Oral cysts	Gastrointestinal
+GI_505.1	Odontogenic cysts	Gastrointestinal
+GI_506	Diseases of salivary glands	Gastrointestinal
+GI_506.1	Atrophy of salivary gland	Gastrointestinal
+GI_506.2	Hypertrophy of salivary gland	Gastrointestinal
+GI_506.3	Sialoadenitis	Gastrointestinal
+GI_506.4	Sialolithiasis	Gastrointestinal
+GI_506.5	Disturbances of salivary secretion	Gastrointestinal
+GI_506.51	Dry mouth*	Gastrointestinal
+GI_506.6	Mucocele of salivary gland	Gastrointestinal
+GI_507	Lesions of mouth	Gastrointestinal
+GI_507.1	Stomatitis	Gastrointestinal
+GI_507.11	Recurrent oral aphthae [Recurrent aphthous stomatitis]	Gastrointestinal
+GI_507.2	Cellulitis and abscess of mouth	Gastrointestinal
+GI_507.3	Oral leukoplakia	Gastrointestinal
+GI_507.31	Hairy leukoplakia*	Gastrointestinal
+GI_507.5	Oral submucosal fibrosis	Gastrointestinal
+GI_508	Diseases of lips	Gastrointestinal
+GI_509	Diseases of tongue	Gastrointestinal
+GI_509.1	Glossitis	Gastrointestinal
+GI_509.11	Glossodynia	Gastrointestinal
+GI_509.12	Geographic tongue	Gastrointestinal
+GI_509.3	Hypertrophy of tongue papillae	Gastrointestinal
+GI_509.4	Atrophy of tongue papillae	Gastrointestinal
+GI_509.5	Plicated tongue	Gastrointestinal
+GI_510	Diseases of esophagus	Gastrointestinal
+GI_510.1	Achalasia of cardia	Gastrointestinal
+GI_510.2	Esophagitis	Gastrointestinal
+GI_510.4	Perforation of esophagus	Gastrointestinal
+GI_510.5	Dyskinesia of esophagus	Gastrointestinal
+GI_510.6	Diverticulum of esophagus	Gastrointestinal
+GI_510.7	Gastroesophageal laceration-hemorrhage syndrome [Mallory-Weiss tear]	Gastrointestinal
+GI_510.8	Barrett's esophagus	Gastrointestinal
+GI_511	Gastro-esophageal reflux disease [GERD]	Gastrointestinal
+GI_512	Aphagia and dysphagia	Gastrointestinal
+GI_513	Peptic ulcer	Gastrointestinal
+GI_513.1	Esophageal ulcer	Gastrointestinal
+GI_513.2	Gastric ulcer	Gastrointestinal
+GI_513.3	Duodenal ulcer	Gastrointestinal
+GI_513.4	Gastrojejunal ulcer	Gastrointestinal
+GI_514	Gastrointestinal obstruction	Gastrointestinal
+GI_514.1	Esophageal obstruction (Stricture and stenosis of esophagus)	Gastrointestinal
+GI_514.2	Intestinal obstruction	Gastrointestinal
+GI_514.21	Impaction of intestine	Gastrointestinal
+GI_514.3	Ileus	Gastrointestinal
+GI_514.31	Paralytic ileus	Gastrointestinal
+GI_515	Heartburn	Gastrointestinal
+GI_516	Other diseases of stomach and duodenum	Gastrointestinal
+GI_516.1	Pyloric stenosis	Gastrointestinal
+GI_516.3	Fistula of stomach and duodenum	Gastrointestinal
+GI_516.4	Gastroparesis	Gastrointestinal
+GI_516.5	Acute dilatation of stomach	Gastrointestinal
+GI_516.6	Achlorhydria	Gastrointestinal
+GI_517	Vascular disorders of intestine	Gastrointestinal
+GI_517.1	Acute vascular insufficiency of intestine	Gastrointestinal
+GI_517.2	Chronic vascular insufficiency of intestine	Gastrointestinal
+GI_517.3	Necrotizing enterocolitis [NEC]	Gastrointestinal
+GI_517.4	Gastrointestinal angiodysplasia	Gastrointestinal
+GI_518	Appendicitis	Gastrointestinal
+GI_520	Hernia	Gastrointestinal
+GI_520.1	Hernia of the abdominal wall	Gastrointestinal
+GI_520.11	Inguinal hernia	Gastrointestinal
+GI_520.12	Femoral hernia	Gastrointestinal
+GI_520.13	Umbilical hernia	Gastrointestinal
+GI_520.14	Ventral hernia	Gastrointestinal
+GI_520.2	Diaphragmatic hernia	Gastrointestinal
+GI_522	Gastrointestinal inflammation	Gastrointestinal
+GI_522.1	Inflammatory bowel disease	Gastrointestinal
+GI_522.11	Crohn's disease	Gastrointestinal
+GI_522.12	Ulcerative colitis	Gastrointestinal
+GI_522.13	Inflammatory polyps of colon [Pseudopolyposis of colon]	Gastrointestinal
+GI_522.14	Microscopic colitis*	Gastrointestinal
+GI_522.4	Toxic gastroenteritis and colitis	Gastrointestinal
+GI_522.5	Allergic and dietetic gastroenteritis and colitis	Gastrointestinal
+GI_522.6	Eosinophilic gastroenteritis and colitis	Gastrointestinal
+GI_522.61	Eosinophilic esophagitis	Gastrointestinal
+GI_522.62	Eosinophilic gastroenteritis	Gastrointestinal
+GI_522.63	Eosinophilic colitis	Gastrointestinal
+GI_522.7	Ulceration of the lower GI tract	Gastrointestinal
+GI_522.8	Duodenitis	Gastrointestinal
+GI_522.9	Gastritis	Gastrointestinal
+GI_522.91	Acute gastritis	Gastrointestinal
+GI_522.92	Atrophic gastritis	Gastrointestinal
+GI_523	Diverticular disease [Bowel diverticulosis]	Gastrointestinal
+GI_523.1	Diverticula of small intestine	Gastrointestinal
+GI_523.2	Diverticula of colon	Gastrointestinal
+GI_523.3	Gastric diverticulum	Gastrointestinal
+GI_523.4	Diverticulitis	Gastrointestinal
+GI_524	Functional intestinal disorder	Gastrointestinal
+GI_524.1	Irritable bowel syndrome	Gastrointestinal
+GI_524.2	Neurogenic bowel	Gastrointestinal
+GI_524.3	Megacolon (other than Hirschsprung's)	Gastrointestinal
+GI_525	Intestinal malabsorption	Gastrointestinal
+GI_525.1	Celiac disease	Gastrointestinal
+GI_525.2	Pancreatic steatorrhea	Gastrointestinal
+GI_526	Intestinal infection	Gastrointestinal
+GI_526.1	Bacterial enteritis	Gastrointestinal
+GI_526.11	Intestinal e.coli	Gastrointestinal
+GI_526.12	Intestinal infection due to C. difficile	Gastrointestinal
+GI_526.2	Viral enteritis	Gastrointestinal
+GI_526.3	Intestinal infection due to protozoa	Gastrointestinal
+GI_527	Abdominal pain	Gastrointestinal
+GI_527.1	Abdominal migraine*	Gastrointestinal
+GI_527.2	Abdominal tenderness	Gastrointestinal
+GI_527.3	Functional dyspepsia	Gastrointestinal
+GI_527.4	Colic	Gastrointestinal
+GI_528	Nausea and vomiting	Gastrointestinal
+GI_528.1	Nausea	Gastrointestinal
+GI_528.2	Vomiting	Gastrointestinal
+GI_529	Symptoms involving digestive system	Gastrointestinal
+GI_529.1	Diarrhea	Gastrointestinal
+GI_529.2	"Flatulence, eructation, and gas pain"	Gastrointestinal
+GI_529.4	Abnormal bowel sounds and visible peristalsis	Gastrointestinal
+GI_529.5	Constipation	Gastrointestinal
+GI_529.6	Halitosis*	Gastrointestinal
+GI_529.7	Fecal incontinence and encopresis	Gastrointestinal
+GI_530	Disease of anus and rectum	Gastrointestinal
+GI_530.1	Anal fissure	Gastrointestinal
+GI_530.2	Anorectal abscess	Gastrointestinal
+GI_530.3	Rectal prolapse	Gastrointestinal
+GI_530.4	Stenosis of anus and rectum	Gastrointestinal
+GI_530.5	Dysplasia of anus	Gastrointestinal
+GI_532	Other disorders of the intestines	Gastrointestinal
+GI_532.1	Intestinal fistula	Gastrointestinal
+GI_532.2	Intestinal perforation	Gastrointestinal
+GI_532.3	Intussusception	Gastrointestinal
+GI_532.4	Volvulus	Gastrointestinal
+GI_535	Intestinal or peritoneal adhesions	Gastrointestinal
+GI_537	Abnormality of the peritoneum	Gastrointestinal
+GI_537.1	Peritonitis	Gastrointestinal
+GI_537.2	Hemoperitoneum	Gastrointestinal
+GI_537.3	Peritoneal abscess	Gastrointestinal
+GI_540	Hepatitis	Gastrointestinal
+GI_540.1	Chronic hepatitis	Gastrointestinal
+GI_540.11	Autoimmune hepatitis	Gastrointestinal
+GI_540.2	Acute hepatitis	Gastrointestinal
+GI_540.3	Viral hepatitits	Gastrointestinal
+GI_540.4	Alcoholic hepatitis	Gastrointestinal
+GI_542	Chronic liver disease	Gastrointestinal
+GI_542.1	Fibrosis and cirrhosis of liver	Gastrointestinal
+GI_542.11	Cirrhosis of liver	Gastrointestinal
+GI_542.2	Fatty liver disease (FLD)	Gastrointestinal
+GI_542.3	Hepatic failure	Gastrointestinal
+GI_542.4	Portal hypertension	Gastrointestinal
+GI_542.5	Hepatorenal syndrome	Gastrointestinal
+GI_542.6	Hepatopulmonary syndrome	Gastrointestinal
+GI_542.7	Chronic nonalcoholic liver disease	Gastrointestinal
+GI_542.8	Biliary cirrhosis	Gastrointestinal
+GI_542.81	Primary biliary cirrhosis*	Gastrointestinal
+GI_542.9	Hepatic necrosis	Gastrointestinal
+GI_545	Nonspecific abnormal results of function study of liver	Gastrointestinal
+GI_546	Other disorders of liver	Gastrointestinal
+GI_546.2	Abscess of liver	Gastrointestinal
+GI_546.3	Hepatomegaly	Gastrointestinal
+GI_546.31	Hepatosplenomegaly*	Gastrointestinal
+GI_546.4	Chronic passive congestion of liver	Gastrointestinal
+GI_546.5	Peliosis hepatis*	Gastrointestinal
+GI_550	Disorders of the gallbladder	Gastrointestinal
+GI_550.1	Gallstones [Cholelithiasis]	Gastrointestinal
+GI_550.2	Cholecystitis	Gastrointestinal
+GI_550.21	Acute cholecystitis	Gastrointestinal
+GI_550.22	Chronic cholecystitis	Gastrointestinal
+GI_550.3	Gallbladder perforation	Gastrointestinal
+GI_550.4	Cholesterolosis of gallbladder	Gastrointestinal
+GI_552	Other diseases of biliary tract	Gastrointestinal
+GI_552.1	Cholangitis	Gastrointestinal
+GI_552.11	Primary sclerosing cholangitis*	Gastrointestinal
+GI_552.2	Obstruction of bile duct	Gastrointestinal
+GI_554	Diseases of the pancreas	Gastrointestinal
+GI_554.1	Pancreatitis	Gastrointestinal
+GI_554.11	Acute pancreatitis	Gastrointestinal
+GI_554.12	Chronic pancreatitis	Gastrointestinal
+GI_554.2	Cyst and pseudocyst of pancreas	Gastrointestinal
+GI_554.3	Exocrine pancreatic insufficiency*	Gastrointestinal
+GI_555	Ascites	Gastrointestinal
+GI_556	Other digestive system symptoms and diseases	Gastrointestinal
+GI_556.3	"Abdominal or pelvic swelling, mass, or lump"	Gastrointestinal
+GI_556.4	Abdominal rigidity	Gastrointestinal
+GI_556.8	Nonspecific abnormal findings in stool contents	Gastrointestinal
+GI_557	Gastrointestinal hemorrhage	Gastrointestinal
+GI_557.1	Hematemesis	Gastrointestinal
+GI_557.2	Blood in stool	Gastrointestinal
+GI_557.8	Hemorrhage of rectum and anus	Gastrointestinal
+GI_558	Abnormal findings on diagnostic imaging of the digestive tract	Gastrointestinal
+GU_580	Glomerular diseases	Genitourinary
+GU_580.1	Acute nephritic syndrome	Genitourinary
+GU_580.2	Chronic nephritic syndrome	Genitourinary
+GU_580.5	Morphologic lesions in glomerular diseases	Genitourinary
+GU_580.51	Focal and segmental glomerular lesions*	Genitourinary
+GU_580.52	Diffuse membranous glomerulonephritis	Genitourinary
+GU_580.53	Diffuse mesangial proliferative glomerulonephritis*	Genitourinary
+GU_580.54	Diffuse endocapillary proliferative glomerulonephritis*	Genitourinary
+GU_580.55	Diffuse mesangiocapillary glomerulonephritis*	Genitourinary
+GU_580.56	Dense deposit disease*	Genitourinary
+GU_580.57	Diffuse crescentic glomerulonephritis*	Genitourinary
+GU_580.58	C3 glomerulonephritis*	Genitourinary
+GU_581	Renal tubulo-interstitial diseases	Genitourinary
+GU_581.1	Acute pyelonephritis	Genitourinary
+GU_581.13	Renal and perinephric abscess	Genitourinary
+GU_581.3	Obstructive and reflux uropathy	Genitourinary
+GU_581.31	Hydronephrosis	Genitourinary
+GU_581.32	Hydroureter	Genitourinary
+GU_581.33	Stricture or kinking of ureter	Genitourinary
+GU_581.34	Vesicoureteral reflux	Genitourinary
+GU_581.35	Chronic pyelonephritis	Genitourinary
+GU_581.4	Drug & heavy metal induced*	Genitourinary
+GU_581.5	Interstial nephritis related to specific systemic diseases	Genitourinary
+GU_582	Renal failure	Genitourinary
+GU_582.1	Acute kidney failure	Genitourinary
+GU_582.2	Chronic kidney disease	Genitourinary
+GU_582.21	"End stage renal disease [CDK, stage 5]"	Genitourinary
+GU_582.3	Renal dialysis	Genitourinary
+GU_585	Kidney stone disease	Genitourinary
+GU_585.1	Renal colic	Genitourinary
+GU_586	Other disorders of the kidney and ureters	Genitourinary
+GU_586.1	Small kidney	Genitourinary
+GU_586.2	Cyst of kidney	Genitourinary
+GU_586.3	Ischemia and infarction of kidney	Genitourinary
+GU_586.4	Hypertrophy of kidney	Genitourinary
+GU_586.5	"Renal sclerosis, unspecified"	Genitourinary
+GU_586.6	Nephroptosis	Genitourinary
+GU_586.7	Megaloureter*	Genitourinary
+GU_588	Disorders and findings from impaired renal function	Genitourinary
+GU_588.1	Disorders resulting from impaired renal function	Genitourinary
+GU_588.11	Renal osteodystrophy	Genitourinary
+GU_588.12	Nephrogenic diabetes insipidus	Genitourinary
+GU_588.2	Abnormal results of function study of kidney	Genitourinary
+GU_591	Urinary tract infection [UTI]	Genitourinary
+GU_592	Cystitis and urethritis	Genitourinary
+GU_592.1	Cystitis	Genitourinary
+GU_592.11	Acute cystitis	Genitourinary
+GU_592.12	Chronic cystitis	Genitourinary
+GU_592.2	Urethritis	Genitourinary
+GU_592.21	Urethral syndrome	Genitourinary
+GU_592.3	Urethral stricture due to infecton	Genitourinary
+GU_593	Hematuria	Genitourinary
+GU_593.1	Gross hematuria	Genitourinary
+GU_593.2	Microscopic hematuria	Genitourinary
+GU_593.3	Recurrent and persistent hematuria*	Genitourinary
+GU_594	Abnormality of urination	Genitourinary
+GU_594.1	Retention of urine	Genitourinary
+GU_594.2	Dysuria	Genitourinary
+GU_594.3	Urinary incontinence and enuresis	Genitourinary
+GU_594.31	Urge incontinence	Genitourinary
+GU_594.32	Stress incontinence	Genitourinary
+GU_594.33	Nocturnal enuresis	Genitourinary
+GU_594.4	Frequency of urination and polyuria	Genitourinary
+GU_594.41	Nocturia	Genitourinary
+GU_594.5	Oliguria and anuria	Genitourinary
+GU_594.6	Urinary urgency	Genitourinary
+GU_596	Other disorders of bladder	Genitourinary
+GU_596.1	Bladder neck obstruction	Genitourinary
+GU_596.2	Overactive bladder	Genitourinary
+GU_596.3	Diverticulum of bladder	Genitourinary
+GU_596.4	Vesical fistula	Genitourinary
+GU_596.5	Neuromuscular dysfunction of bladder	Genitourinary
+GU_597	Other disorders of urethra and urinary tract	Genitourinary
+GU_597.1	Urethral stricture	Genitourinary
+GU_597.2	Muscular disorders of urethra [Detrusor sphincter dyssynergia]	Genitourinary
+GU_597.3	Urethral fistula	Genitourinary
+GU_597.4	Urethral diverticulum	Genitourinary
+GU_597.5	Urethral caruncle	Genitourinary
+GU_597.6	Urethral false passage	Genitourinary
+GU_597.8	Urethral hypermobility/ISD	Genitourinary
+GU_598	Abnormal findings on radiological and other examination of genitourinary organs	Genitourinary
+GU_599	Other symptoms/disorders or the urinary system	Genitourinary
+GU_599.7	Urethral discharge	Genitourinary
+GU_602	Disorders of prostate	Genitourinary
+GU_602.1	Benign prostatic hyperplasia	Genitourinary
+GU_602.2	Cyst of prostate	Genitourinary
+GU_602.3	Dysplasia of prostate	Genitourinary
+GU_602.4	Elevated prostate specific antigen [PSA]	Genitourinary
+GU_602.5	Inflammatory diseases of prostate	Genitourinary
+GU_602.51	Prostatitis	Genitourinary
+GU_602.511	Acute prostatitis	Genitourinary
+GU_602.512	Chronic prostatitis	Genitourinary
+GU_603	Disorders of testis	Genitourinary
+GU_603.1	Hydrocele	Genitourinary
+GU_603.2	Spermatocele	Genitourinary
+GU_603.3	Torsion of testis	Genitourinary
+GU_603.4	Atrophy of testis	Genitourinary
+GU_603.5	Orchitis and epididymitis	Genitourinary
+GU_603.6	Scrotal pain*	Genitourinary
+GU_604	Disorders of penis	Genitourinary
+GU_604.1	Redundant prepuce and phimosis	Genitourinary
+GU_604.3	Peyronie's disease	Genitourinary
+GU_604.4	Priapism	Genitourinary
+GU_604.5	Balanoposthitis	Genitourinary
+GU_605	Male sexual dysfuction	Genitourinary
+GU_605.1	Male erectile dysfunction*	Genitourinary
+GU_605.2	Ejaculatory dysfunction	Genitourinary
+GU_608	Other disorders of male genital organs	Genitourinary
+GU_609	Male infertility	Genitourinary
+GU_609.1	Azoospermia	Genitourinary
+GU_609.2	Oligospermia	Genitourinary
+GU_610	Benign mammary dysplasias	Genitourinary
+GU_610.1	Cystic mastopathy	Genitourinary
+GU_610.2	Fibroadenosis of breast	Genitourinary
+GU_610.3	Fibrosclerosis of breast	Genitourinary
+GU_610.5	Mammary duct ectasia	Genitourinary
+GU_612	Other nonmalignant breast conditions	Genitourinary
+GU_612.1	Inflammatory disease of breast	Genitourinary
+GU_612.2	"Breast conditions, congenital or relating to hormones"	Genitourinary
+GU_612.21	Galactorrhea	Genitourinary
+GU_612.22	Hypertrophy of breast (Gynecomastia)	Genitourinary
+GU_612.23	Breast hypoplasia	Genitourinary
+GU_612.5	Mastodynia	Genitourinary
+GU_612.7	Other signs and symptoms in breast	Genitourinary
+GU_612.8	Other specified disorders of breast	Genitourinary
+GU_614	Inflammatory diseases of female pelvic organs	Genitourinary
+GU_614.1	"Pelvic peritoneal adhesions, female (postoperative) (postinfection)"	Genitourinary
+GU_614.3	Pelvic inflammatory disease (PID)	Genitourinary
+GU_614.31	Acute inflammatory pelvic disease	Genitourinary
+GU_614.32	Chronic inflammatory pelvic disease	Genitourinary
+GU_614.4	"Inflammatory diseases of uterus, except cervix"	Genitourinary
+GU_614.5	"Inflammatory disease of cervix, vagina, and vulva"	Genitourinary
+GU_614.51	Cervicitis and endocervicitis	Genitourinary
+GU_614.52	Vaginitis and vulvovaginitis	Genitourinary
+GU_614.53	Cyst or abscess of Bartholin's gland	Genitourinary
+GU_614.54	Abscess or ulceration of vulva	Genitourinary
+GU_614.55	Candidiasis of vulva and vagina	Genitourinary
+GU_615	Endometriosis	Genitourinary
+GU_616	"Disorders of uterus, except cervix"	Genitourinary
+GU_616.1	Endometrial hyperplasia	Genitourinary
+GU_616.2	Hypertrophy of uterus	Genitourinary
+GU_616.3	Malposition of uterus	Genitourinary
+GU_616.4	Intrauterine synechiae	Genitourinary
+GU_617	Noninflammatory disorders of cervix	Genitourinary
+GU_617.1	Incompetence of cervix uteri	Genitourinary
+GU_617.2	Erosion and ectropion of cervix	Genitourinary
+GU_617.3	Stricture and stenosis of cervix	Genitourinary
+GU_618	Noninflammatory disorders of vagina	Genitourinary
+GU_618.1	Stricture and atresia of vagina	Genitourinary
+GU_618.3	Atrophic vaginitis	Genitourinary
+GU_619	"Noninflammatory disorders of ovary, fallopian tube, and broad ligament"	Genitourinary
+GU_619.1	Torsion of ovary	Genitourinary
+GU_619.2	Ovarian cyst	Genitourinary
+GU_619.21	Follicular cyst of ovary	Genitourinary
+GU_619.22	Corpus luteum cyst or hematoma	Genitourinary
+GU_619.23	Polycystic ovary syndrome	Genitourinary
+GU_620	Noninflammatory disorders of vulva and perineum	Genitourinary
+GU_621	Dysplasia of female genital organs	Genitourinary
+GU_621.1	Dysplasia of cervix	Genitourinary
+GU_622	Polyp of female genital organs	Genitourinary
+GU_622.1	Polyp of corpus uteri	Genitourinary
+GU_622.2	Mucous polyp of cervix	Genitourinary
+GU_623	Pelvic organ prolapse and fistulas	Genitourinary
+GU_623.1	Uterine/Uterovaginal prolapse	Genitourinary
+GU_623.5	Pelvic muscle wasting	Genitourinary
+GU_623.6	"Vaginal enterocele, congenital or acquired"	Genitourinary
+GU_623.8	Fistula involving female genital tract	Genitourinary
+GU_624	Symptoms involving female genital tract	Genitourinary
+GU_624.1	Dystrophy of female genital tract	Genitourinary
+GU_624.2	Acquired atrophy of ovary and fallopian tube	Genitourinary
+GU_625	Pain and other symptoms associated with female genital organs	Genitourinary
+GU_625.1	Dyspareunia	Genitourinary
+GU_625.2	Postcoital bleeding	Genitourinary
+GU_625.3	Vulvodynia	Genitourinary
+GU_625.4	Vaginismus	Genitourinary
+GU_626	Disorders of menstruation and other abnormal bleeding from female genital tract	Genitourinary
+GU_626.1	Irregular menstrual cycle/bleeding	Genitourinary
+GU_626.11	Oligomenorrhea	Genitourinary
+GU_626.111	Amenorrhea	Genitourinary
+GU_626.13	Irregular menstrual cycle	Genitourinary
+GU_626.16	Excessive menstruation	Genitourinary
+GU_626.2	Dysmenorrhea	Genitourinary
+GU_626.3	Mittelschmerz	Genitourinary
+GU_626.4	Hematometra and hematocolpos	Genitourinary
+GU_627	Menopausal and postmenopausal disorders	Genitourinary
+GU_627.1	Postmenopausal bleeding	Genitourinary
+GU_627.2	Symptomatic menopause	Genitourinary
+GU_629	Female infertility	Genitourinary
+GU_629.1	Female infertility associated with anovulation	Genitourinary
+DE_660	Infection of the skin	Dermatological
+DE_660.1	Fungal infection of the skin	Dermatological
+DE_660.11	Candidiasis of skin and nails	Dermatological
+DE_660.12	Dermatophytosis	Dermatological
+DE_660.121	Dermatophytosis of scalp and beard	Dermatological
+DE_660.122	Dermatophytosis of nail	Dermatological
+DE_660.123	Dermatophytosis of foot [Athelet's foot]	Dermatological
+DE_660.124	Dermatophytosis of the body	Dermatological
+DE_660.13	Pityriasis versicolor	Dermatological
+DE_660.2	Bacterial infection of the skin	Dermatological
+DE_660.21	Impetigo	Dermatological
+DE_660.22	Staphylococcal scalded skin syndrome [Ritter's disease]	Dermatological
+DE_660.23	Cutaneous erysipeloid	Dermatological
+DE_660.4	Carbuncle and furuncle	Dermatological
+DE_660.6	Cellulitis and abscess	Dermatological
+DE_661	Viral exanthemata NOS	Dermatological
+DE_662	Rosacea	Dermatological
+DE_663	Bullous disorders	Dermatological
+DE_663.1	Pemphigus	Dermatological
+DE_663.11	Pemphigus vulgaris*	Dermatological
+DE_663.12	Pemphigus foliaceous*	Dermatological
+DE_663.2	Pemphigoid	Dermatological
+DE_663.3	Dermatitis herpetiformis	Dermatological
+DE_663.4	Subcorneal pustular dermatosis	Dermatological
+DE_663.6	Acantholytic Disorders*	Dermatological
+DE_664	Papulosquamous disorders	Dermatological
+DE_664.1	"Lichen planus, nitidus, or striatus"	Dermatological
+DE_664.2	Pityriasis	Dermatological
+DE_664.3	Parapsoriasis	Dermatological
+DE_664.4	Psoriasis	Dermatological
+DE_664.41	Psoriasis vulgaris*	Dermatological
+DE_664.42	Psoriatic arthropathy	Dermatological
+DE_665	Erythema nodosum	Dermatological
+DE_666	Urticaria	Dermatological
+DE_666.1	Allergic urticaria	Dermatological
+DE_666.2	Idiopathic urticaria	Dermatological
+DE_666.3	Urticaria due to cold and heat	Dermatological
+DE_666.4	Dermatographic urticaria	Dermatological
+DE_666.5	Vibratory urticaria	Dermatological
+DE_666.6	Cholinergic urticaria	Dermatological
+DE_667	Erythematous conditions	Dermatological
+DE_667.1	Erythema multiforme	Dermatological
+DE_667.2	Stevens-Johnson syndrome and Toxic epidermal necrolysis	Dermatological
+DE_667.4	Toxic erythema	Dermatological
+DE_667.5	Exfoliation due to erythematous condition	Dermatological
+DE_668	Dermatitis [eczema]	Dermatological
+DE_668.1	Atopic dermatitis	Dermatological
+DE_668.2	Seborrheic dermatitis	Dermatological
+DE_668.3	Contact dermatitis	Dermatological
+DE_668.4	Dermatitis due to substances taken internally	Dermatological
+DE_668.5	Lichen simplex chronicus	Dermatological
+DE_668.6	Prurigo	Dermatological
+DE_668.7	Seborrheic infantile dermatitis	Dermatological
+DE_669	Neutrophilic and Eosinophilic dermatoses	Dermatological
+DE_669.1	Pyoderma gangrenosum	Dermatological
+DE_669.2	Behcet's syndrome	Dermatological
+DE_669.3	Hidradenitis suppurativa	Dermatological
+DE_669.4	Febrile neutrophilic dermatosis [Sweet's syndrome]*	Dermatological
+DE_670	Seborrheic keratosis	Dermatological
+DE_672	Skin changes due to solar radiation	Dermatological
+DE_672.1	Acute skin changes due to ultraviolet radiation	Dermatological
+DE_672.11	Acute dermatitis due to solar radiation	Dermatological
+DE_672.12	Sunburn	Dermatological
+DE_672.14	Disseminated superficial actinic porokeratosis (DSAP)	Dermatological
+DE_672.2	Skin changes due to chronic exposure to nonionizing radiation	Dermatological
+DE_672.21	Actinic keratosis	Dermatological
+DE_672.22	Actinic reticuloid and actinic granuloma	Dermatological
+DE_674	Disorders of pigmentation	Dermatological
+DE_674.1	Hypopigmentation	Dermatological
+DE_674.11	Vitiligo	Dermatological
+DE_674.2	Hypepigmentation*	Dermatological
+DE_674.21	Cafe au lait spots*	Dermatological
+DE_674.22	Freckles*	Dermatological
+DE_675	Atrophic conditions of skin	Dermatological
+DE_675.1	Circumscribed scleroderma	Dermatological
+DE_675.2	Striae atrophicae	Dermatological
+DE_676	Hypertrophic conditions of skin	Dermatological
+DE_676.1	Hypertrophic scar [Keloid scar]	Dermatological
+DE_676.2	Scar conditions and fibrosis of skin	Dermatological
+DE_677	Chilblains	Dermatological
+DE_678	Other skin and subcutaneous disorders	Dermatological
+DE_679	Skin symptoms	Dermatological
+DE_679.1	Rash and other nonspecific skin eruption	Dermatological
+DE_679.2	Pallor	Dermatological
+DE_679.3	Flushing	Dermatological
+DE_679.4	Pruritus	Dermatological
+DE_679.5	Pyoderma	Dermatological
+DE_679.6	Changes in skin texture	Dermatological
+DE_680	Epidermal thickening	Dermatological
+DE_680.1	Corns and callosities	Dermatological
+DE_680.2	Keratoderma	Dermatological
+DE_680.3	Xerosis cutis*	Dermatological
+DE_680.4	Ainhum	Dermatological
+DE_680.5	Acanthosis nigricans	Dermatological
+DE_681	"Localized swelling, mass and lump of skin and subcutaneous tissue"	Dermatological
+DE_682	Other follicular disorders	Dermatological
+DE_682.1	Cutaneous cyst	Dermatological
+DE_682.11	Sebaceous cyst [Epidermal cyst]	Dermatological
+DE_682.12	Pilar and trichodermal cyst	Dermatological
+DE_682.2	Pilonidal cyst	Dermatological
+DE_682.4	Acne	Dermatological
+DE_683	Nail disorders	Dermatological
+DE_683.1	Ingrowing nail	Dermatological
+DE_683.2	Nail dystrophy*	Dermatological
+DE_683.4	Onycholysis*	Dermatological
+DE_684	Diseases of hair and hair follicles	Dermatological
+DE_684.1	Alopecia	Dermatological
+DE_684.11	Alopecia Areata	Dermatological
+DE_684.12	Telogen effluvium	Dermatological
+DE_684.13	Scarring hair loss*	Dermatological
+DE_684.14	Androgenic alopecia*	Dermatological
+DE_684.2	Hypertrichosis and hirsutism	Dermatological
+DE_684.21	Hirsutism*	Dermatological
+DE_684.8	Abnormalities of the hair	Dermatological
+DE_685	Disorders of sweat glands	Dermatological
+DE_685.1	Dyshidrosis	Dermatological
+DE_685.4	Prickly heat and miliaria	Dermatological
+DE_685.5	Anhidrosis	Dermatological
+DE_685.8	Hyperhidrosis	Dermatological
+DE_685.81	Primary focal hyperhidrosis	Dermatological
+DE_685.82	Generalized hyperhidrosis	Dermatological
+DE_686	Chronic ulcer of skin	Dermatological
+DE_686.1	Pressure ulcer	Dermatological
+DE_686.2	Non-pressure chronic ulcer	Dermatological
+DE_687	Vascular disorders of the skin	Dermatological
+DE_688	Granulomatous disorder of the skin	Dermatological
+DE_688.1	Sarcoidosis	Dermatological
+DE_688.2	Foreign body granuloma	Dermatological
+DE_688.3	Pyogenic granuloma of skin and subcutaneous tissue	Dermatological
+DE_688.5	Giant cell granuloma	Dermatological
+MS_700	Diffuse diseases of connective tissue	Muscloskeletal
+MS_700.1	Lupus	Muscloskeletal
+MS_700.11	Systemic lupus erythematosus [SLE]	Muscloskeletal
+MS_700.12	Cutaneous lupus erythematosus	Muscloskeletal
+MS_700.2	Sicca syndrome [Sjogren syndrome]	Muscloskeletal
+MS_700.3	Systemic sclerosis	Muscloskeletal
+MS_700.4	Inflammatory myopathy	Muscloskeletal
+MS_700.41	Myositis	Muscloskeletal
+MS_700.42	Dermatomyositis	Muscloskeletal
+MS_700.43	Polymyositis	Muscloskeletal
+MS_700.44	Inclusion body myositis	Muscloskeletal
+MS_700.6	Autoinflammatory syndromes*	Muscloskeletal
+MS_700.7	Multisystem inflammatory syndrome*	Muscloskeletal
+MS_701	"Osteomyelitis, periostitis, and other infections involving bone"	Muscloskeletal
+MS_701.1	Osteomyelitis	Muscloskeletal
+MS_701.11	Acute/subacute osteomyelitis	Muscloskeletal
+MS_701.12	Chronic osteomyelitis	Muscloskeletal
+MS_702	Infective and reactive arthropathies	Muscloskeletal
+MS_702.1	Pyogenic arthritis [Septic arthritis]	Muscloskeletal
+MS_702.2	Reiter's disease [Reactive arthritis]	Muscloskeletal
+MS_702.3	Enteropathic arthropathies	Muscloskeletal
+MS_703	Chrystal arthropathies	Muscloskeletal
+MS_703.1	Gout	Muscloskeletal
+MS_703.2	Chondrocalcinosis	Muscloskeletal
+MS_703.3	Hydroxyapatite deposition disease*	Muscloskeletal
+MS_704	Systemic vasculitis	Muscloskeletal
+MS_704.1	Polyarteritis nodosa and related conditions	Muscloskeletal
+MS_704.11	Polyarteritis nodosa	Muscloskeletal
+MS_704.12	Mucocutaneous lymph node syndrome [Kawasaki]	Muscloskeletal
+MS_704.13	ANCA-associated vasculitides*	Muscloskeletal
+MS_704.2	Wegener's granulomatosis	Muscloskeletal
+MS_704.3	Thrombotic microangiopathy	Muscloskeletal
+MS_704.4	Hypersensitivity angiitis	Muscloskeletal
+MS_704.5	Giant cell arteritis	Muscloskeletal
+MS_704.6	Aortic arch syndrome [Takayasu's disease]	Muscloskeletal
+MS_704.7	Cerebral arteritis	Muscloskeletal
+MS_704.8	Thromboangiitis obliterans [Buerger's disease]	Muscloskeletal
+MS_704.9	Allergic purpura [Henoch-Schoenlein purpura]	Muscloskeletal
+MS_705	Rheumatoid arthritis and other inflammatory polyarthropathies	Muscloskeletal
+MS_705.1	Rheumatoid arthritis	Muscloskeletal
+MS_705.11	Rheumatoid arthritis without rheumatoid factor*	Muscloskeletal
+MS_705.12	Rheumatoid arthritis with rheumatoid factor*	Muscloskeletal
+MS_705.2	Juvenile rheumatoid arthritis [JRA/JIA]	Muscloskeletal
+MS_705.3	Polymyalgia rheumatica	Muscloskeletal
+MS_705.4	Palindromic rheumatism	Muscloskeletal
+MS_705.5	"Rheumatism, unspecified"	Muscloskeletal
+MS_705.6	Chronic postrheumatic arthropathy [Jaccoud]	Muscloskeletal
+MS_706	Inflammatory spondylopathies	Muscloskeletal
+MS_706.1	Sacroiliitis	Muscloskeletal
+MS_706.2	Ankylosing spondylitis	Muscloskeletal
+MS_706.3	Spinal enthesopathy	Muscloskeletal
+MS_707	Other arthropathies	Muscloskeletal
+MS_707.1	Villonodular synovitis	Muscloskeletal
+MS_707.2	Traumatic arthropathy	Muscloskeletal
+MS_707.3	Kaschin-Beck disease	Muscloskeletal
+MS_707.8	Polyarthritis	Muscloskeletal
+MS_707.9	Monoarthritis	Muscloskeletal
+MS_708	Osteoarthritis	Muscloskeletal
+MS_708.1	Osteoarthritis of more than one site	Muscloskeletal
+MS_708.11	Generalized osteoarthritis	Muscloskeletal
+MS_709	Acquired deformities of fingers and toes	Muscloskeletal
+MS_709.1	Acquired deformities of fingers	Muscloskeletal
+MS_709.11	Mallet finger	Muscloskeletal
+MS_709.12	Boutonniere deformity	Muscloskeletal
+MS_709.13	Swan-neck deformity	Muscloskeletal
+MS_709.2	Acquired deformities of toe	Muscloskeletal
+MS_709.21	Hallux valgus (Bunion)	Muscloskeletal
+MS_709.22	Hallux rigidus	Muscloskeletal
+MS_709.23	Hallux varus	Muscloskeletal
+MS_709.24	Hammer toe	Muscloskeletal
+MS_710	Acquired deformities of limbs	Muscloskeletal
+MS_710.1	Acquired deformities of the forearm and hand	Muscloskeletal
+MS_710.11	Wrist drop	Muscloskeletal
+MS_710.12	Acquired clawhand	Muscloskeletal
+MS_710.13	Acquired clubhand	Muscloskeletal
+MS_710.2	Deformities of the hip	Muscloskeletal
+MS_710.21	Coxa valga	Muscloskeletal
+MS_710.22	Coxa vara	Muscloskeletal
+MS_710.23	Protrusio acetabuli	Muscloskeletal
+MS_710.3	Deformities of the knee	Muscloskeletal
+MS_710.31	Genu valgum (acquired)	Muscloskeletal
+MS_710.32	Genu varum (acquired)	Muscloskeletal
+MS_710.4	Acquired deformities of the ankle and foot	Muscloskeletal
+MS_710.41	Flat foot [pes planus]	Muscloskeletal
+MS_710.42	Club foot	Muscloskeletal
+MS_710.43	Cavus deformity of foot	Muscloskeletal
+MS_710.44	Foot drop (acquired)*	Muscloskeletal
+MS_710.45	Claw foot (acquired)	Muscloskeletal
+MS_710.6	Unequal limb length (acquired)	Muscloskeletal
+MS_711	Disorder of patella	Muscloskeletal
+MS_711.1	Derangement of meniscus	Muscloskeletal
+MS_712	Joint derangements and related disorders	Muscloskeletal
+MS_712.1	Loose body in joint	Muscloskeletal
+MS_712.3	Articular cartilage disorder	Muscloskeletal
+MS_712.4	Ankylosis of joint	Muscloskeletal
+MS_712.5	Disorder of ligament	Muscloskeletal
+MS_712.51	Hypermobility syndrome	Muscloskeletal
+MS_712.6	Instability of joint	Muscloskeletal
+MS_712.61	Recurrent dislocation of joint	Muscloskeletal
+MS_712.62	Pathological dislocation of joint	Muscloskeletal
+MS_712.63	Spinal instabilities*	Muscloskeletal
+MS_713	Symptoms related to joints	Muscloskeletal
+MS_713.1	Hemarthrosis	Muscloskeletal
+MS_713.2	Effusion of joint	Muscloskeletal
+MS_713.3	Pain in joint	Muscloskeletal
+MS_713.31	Pain in shoulder	Muscloskeletal
+MS_713.32	Pain in elbow	Muscloskeletal
+MS_713.34	Pain in wrist*	Muscloskeletal
+MS_713.35	Pain in joints of hand	Muscloskeletal
+MS_713.36	Pain in hip	Muscloskeletal
+MS_713.37	Pain in knee	Muscloskeletal
+MS_713.38	Pain in ankle and joints of foot	Muscloskeletal
+MS_713.4	Stiffness of joint	Muscloskeletal
+MS_713.5	Clicking hip*	Muscloskeletal
+MS_714	Deforming dorsopathies	Muscloskeletal
+MS_714.1	Kyphosis	Muscloskeletal
+MS_714.2	Lordosis	Muscloskeletal
+MS_714.3	Scoliosis	Muscloskeletal
+MS_714.31	Idiopathic scoliosis	Muscloskeletal
+MS_714.32	Thoracogenic scoliosis	Muscloskeletal
+MS_714.5	Spondylolysis	Muscloskeletal
+MS_714.6	Spondylolisthesis	Muscloskeletal
+MS_714.7	Fusion of spine*	Muscloskeletal
+MS_715	Other non-inflammatory spondylopathy	Muscloskeletal
+MS_715.1	Spondylosis	Muscloskeletal
+MS_715.4	Spinal stenosis	Muscloskeletal
+MS_715.5	Ankylosing hyperostosis [Forestier]	Muscloskeletal
+MS_715.6	Kissing spine	Muscloskeletal
+MS_716	Intervertebral disc disorder	Muscloskeletal
+MS_716.1	Schmorl's nodes	Muscloskeletal
+MS_716.2	Degenerative disc disease	Muscloskeletal
+MS_716.3	Spinal disc displacement (herniation)	Muscloskeletal
+MS_717	Other and unspecified dorsopathies	Muscloskeletal
+MS_717.1	Cervicocranial syndrome	Muscloskeletal
+MS_717.2	Sacrococcygeal disorders	Muscloskeletal
+MS_717.3	Occipital neuralgia*	Muscloskeletal
+MS_718	Back pain	Muscloskeletal
+MS_718.1	Radiculopathy	Muscloskeletal
+MS_718.2	Cervicalgia	Muscloskeletal
+MS_718.3	Mid back pain	Muscloskeletal
+MS_718.4	Low back pain	Muscloskeletal
+MS_718.5	Sciatica	Muscloskeletal
+MS_719	Disorders of muscle	Muscloskeletal
+MS_719.1	Cramp and spasm	Muscloskeletal
+MS_719.11	Spasm of muscle	Muscloskeletal
+MS_719.2	Muscle calcification and ossification	Muscloskeletal
+MS_719.21	Myositis ossificans progressiva	Muscloskeletal
+MS_719.22	Myositis ossificans traumatica	Muscloskeletal
+MS_719.3	Separation of muscle (nontraumatic)	Muscloskeletal
+MS_719.4	Rupture of muscle (nontraumatic)	Muscloskeletal
+MS_719.5	Compartment syndrome and nontraumatic ischemic infarction of muscle	Muscloskeletal
+MS_719.6	Muscle wasting and atrophy	Muscloskeletal
+MS_719.61	Sarcopenia*	Muscloskeletal
+MS_719.8	Rhabdomyolysis	Muscloskeletal
+MS_719.9	Contractures	Muscloskeletal
+MS_719.91	Contracture of tendon	Muscloskeletal
+MS_719.92	Contracture of joint	Muscloskeletal
+MS_719.93	Contracture of muscle*	Muscloskeletal
+MS_720	Spontaneous rupture of synovium and tendon	Muscloskeletal
+MS_721	Synoviopathy and bursopathy	Muscloskeletal
+MS_721.1	Synovitis and tenosynovitis	Muscloskeletal
+MS_721.11	Trigger finger	Muscloskeletal
+MS_721.12	Radial styloid tenosynovitis [de Quervain]	Muscloskeletal
+MS_721.15	Infective (teno)synovitis*	Muscloskeletal
+MS_721.16	Transient synovitis*	Muscloskeletal
+MS_721.2	Ganglion cyst	Muscloskeletal
+MS_721.3	Plica syndrome	Muscloskeletal
+MS_721.4	Calcium deposits in tendon and bursa	Muscloskeletal
+MS_721.5	Bursitis	Muscloskeletal
+MS_721.6	Baker's cyst [popliteal cyst]	Muscloskeletal
+MS_721.7	Synovial hypertrophy*	Muscloskeletal
+MS_722	Fasciopathy	Muscloskeletal
+MS_722.1	Plantar fascial fibromatosis [Plantar fasciitis]	Muscloskeletal
+MS_722.2	Pseudosarcomatous fibromatosis [Nodular fasciitis]*	Muscloskeletal
+MS_722.3	Necrotizing fasciitis	Muscloskeletal
+MS_722.4	Palmar fascial fibromatosis [Dupuytren]	Muscloskeletal
+MS_723	Enthesopathy/Enthesitis/Tendinopathy	Muscloskeletal
+MS_723.1	Adhesive capsulitis of shoulder	Muscloskeletal
+MS_723.2	Rotator cuff tear or rupture	Muscloskeletal
+MS_723.3	Medial epicondylitis (Golfer's elbow)	Muscloskeletal
+MS_723.4	Lateral epicondylitis (Tennis elbow)	Muscloskeletal
+MS_723.5	Tendinitis	Muscloskeletal
+MS_723.51	Achilles tendinitis	Muscloskeletal
+MS_723.52	Posterior tibial tendinitis	Muscloskeletal
+MS_723.6	Impingement syndrome of shoulder*	Muscloskeletal
+MS_723.7	Iliotibial band syndrome*	Muscloskeletal
+MS_724	Other symptoms and disorders of the soft tissue	Muscloskeletal
+MS_724.1	Myalgia	Muscloskeletal
+MS_724.2	Hypertrophy of (infrapatellar) fat pad	Muscloskeletal
+MS_724.3	Nontraumatic hematoma of soft tissue	Muscloskeletal
+MS_724.4	Panniculitis	Muscloskeletal
+MS_724.5	Exostosis	Muscloskeletal
+MS_724.51	Calcaneal spur	Muscloskeletal
+MS_724.52	Osteophyte*	Muscloskeletal
+MS_725	Osteochondrosis	Muscloskeletal
+MS_725.1	Spinal osteochondrosis	Muscloskeletal
+MS_726	Osteoporosis and low bone density	Muscloskeletal
+MS_726.1	Osteoporosis	Muscloskeletal
+MS_726.5	Osteomalacia	Muscloskeletal
+MS_726.6	Osteolysis*	Muscloskeletal
+MS_726.7	Major osseous defects	Muscloskeletal
+MS_726.8	Skeletal fluorosis*	Muscloskeletal
+MS_727	Other disorders of bone	Muscloskeletal
+MS_727.1	Osteonecrosis	Muscloskeletal
+MS_727.2	Hypertrophic osteoarthropathy [Hypertrophic pulmonary osteoarthropathy]	Muscloskeletal
+MS_727.3	Osteitis deformans [Paget's disease of bone]	Muscloskeletal
+MS_727.4	Hyperostosis of skull	Muscloskeletal
+MS_727.5	Cyst of bone	Muscloskeletal
+MS_727.6	Hypertrophy of bone*	Muscloskeletal
+MS_727.7	Osteitis condensans	Muscloskeletal
+MS_728	Chondropathies	Muscloskeletal
+MS_728.1	Chondromalacia	Muscloskeletal
+MS_728.2	Osteochondritis dissecans	Muscloskeletal
+MS_728.3	Costochondritis [Tietze's disease]	Muscloskeletal
+MS_728.4	Nontraumatic slipped upper femoral epiphysis	Muscloskeletal
+MS_728.6	Chondrolysis*	Muscloskeletal
+MS_728.7	Relapsing polychondritis*	Muscloskeletal
+MS_728.8	Kienbock's disease of adults*	Muscloskeletal
+MS_729	Other acquired musculoskeletal deformity	Muscloskeletal
+MS_730	Other disorders and symptoms of the musculoskeletal system	Muscloskeletal
+MS_730.1	Segmental and somatic dysfunction	Muscloskeletal
+MS_730.3	Immobility syndrome (paraplegic)*	Muscloskeletal
+MS_730.4	Loss of height	Muscloskeletal
+MS_732	Nonspecific abnormal findings on radiological and other examination of musculoskeletal system	Muscloskeletal
+MS_733	"Dentofacial anomalies, including malocclusion"	Muscloskeletal
+MS_733.1	Major anomalies of jaw size	Muscloskeletal
+MS_733.11	Hyperplasia of jaw	Muscloskeletal
+MS_733.111	Maxillary hyperplasia	Muscloskeletal
+MS_733.112	Mandibular hyperplasia	Muscloskeletal
+MS_733.113	Macrogenia	Muscloskeletal
+MS_733.12	Hypoplasia of jaw	Muscloskeletal
+MS_733.121	Maxillary hypoplasia	Muscloskeletal
+MS_733.122	Mandibular hypoplasia	Muscloskeletal
+MS_733.123	Microgenia	Muscloskeletal
+MS_733.2	Anomalies of dental arch relationship	Muscloskeletal
+MS_733.3	Anomalies of tooth position	Muscloskeletal
+MS_733.31	Crowding of teeth	Muscloskeletal
+MS_733.4	Dentofacial functional abnormalities	Muscloskeletal
+MS_733.41	Limited mandibular range of motion	Muscloskeletal
+MS_733.7	Anomalies of jaw-cranial base relationship	Muscloskeletal
+MS_734	Diseases of the jaws	Muscloskeletal
+MS_734.4	Alveolitis of jaw	Muscloskeletal
+MS_734.5	Inflammatory conditions of jaw	Muscloskeletal
+MS_734.6	Temporomandibular joint disorders	Muscloskeletal
+MS_734.61	Adhesions and ankylosis of temporomandibular joint	Muscloskeletal
+MS_734.62	Arthralgia of temporomandibular joint	Muscloskeletal
+MS_734.63	Temporomandibular joint disorders articular disc disorder (reducing or non-reducing)	Muscloskeletal
+MS_734.9	Jaw pain	Muscloskeletal
+MS_740	Dislocation	Muscloskeletal
+MS_740.1	Dislocation of jaw	Muscloskeletal
+MS_740.2	Dislocation of shoulder	Muscloskeletal
+MS_740.3	Dislocation of elbow	Muscloskeletal
+MS_740.4	Dislocation of wrist and hand	Muscloskeletal
+MS_740.5	Dislocation of finger	Muscloskeletal
+MS_740.6	Dislocation of hip	Muscloskeletal
+MS_740.7	Dislocation of knee	Muscloskeletal
+MS_740.8	Dislocation of foot and ankle	Muscloskeletal
+MS_740.9	Dislocation of vertebra or sternum	Muscloskeletal
+MS_741	Sprains and strains	Muscloskeletal
+MS_741.1	Sprains and strains of shoulder and upper arm	Muscloskeletal
+MS_741.11	Acromioclavicular (joint) (ligament) sprain	Muscloskeletal
+MS_741.13	Superior glenoid labrum lesion	Muscloskeletal
+MS_741.14	Rotator cuff (capsule) sprain	Muscloskeletal
+MS_741.2	Sprains and strains of elbow and forearm	Muscloskeletal
+MS_741.3	Sprains and strains of wrist and hand	Muscloskeletal
+MS_741.4	Sprains and strains of hip and thigh	Muscloskeletal
+MS_741.5	Sprains and strains of knee and leg	Muscloskeletal
+MS_741.6	Sprains and strains of ankle and foot	Muscloskeletal
+MS_741.7	Back sprain	Muscloskeletal
+MS_741.71	Lumbosacral sprain	Muscloskeletal
+MS_741.72	Neck sprain	Muscloskeletal
+MS_742	Cartilage tear of knee	Muscloskeletal
+MS_745	Fractures	Muscloskeletal
+MS_745.1	Fracture of lower limb	Muscloskeletal
+MS_745.11	Fracture of femur	Muscloskeletal
+MS_745.2	Fracture of pelvis	Muscloskeletal
+MS_745.3	Fracture of upper limb	Muscloskeletal
+MS_745.4	Fracture of foot and toe	Muscloskeletal
+MS_745.5	Fracture of hand or wrist	Muscloskeletal
+MS_745.6	Fracture of bones in thorax	Muscloskeletal
+MS_745.61	Fracture of vertebrae	Muscloskeletal
+MS_745.7	Skull and face fracture	Muscloskeletal
+MS_745.8	Stress fracture	Muscloskeletal
+MS_745.9	Pathological fracture	Muscloskeletal
+CM_750	Congenital malformations of nervous system	Congenital
+CM_750.1	Congenital malformations of brain	Congenital
+CM_750.11	Aplasia/Hypoplasia of the brain	Congenital
+CM_750.111	Microcephaly	Congenital
+CM_750.112	Anencephalus and similar anomalies	Congenital
+CM_750.113	Congenital reduction deformities of brain	Congenital
+CM_750.114	Septo-optic dysplasia of brain*	Congenital
+CM_750.115	Holoprosencephaly*	Congenital
+CM_750.12	Congenital malformations of corpus callosum*	Congenital
+CM_750.13	Megalencephaly*	Congenital
+CM_750.14	Congenital cerebral cysts*	Congenital
+CM_750.15	Congenital hydrocephalus	Congenital
+CM_750.151	Malformations of aqueduct of Sylvius*	Congenital
+CM_750.152	Atresia of foramina of Magendie and Luschka*	Congenital
+CM_750.16	Arnold-Chiari syndrome*	Congenital
+CM_750.2	Neural tube defects and congenital disorders of the spinal cord	Congenital
+CM_750.21	Spina bifida	Congenital
+CM_750.22	Spina bifida occulta	Congenital
+CM_750.23	Congenital sacral dimple*	Congenital
+CM_750.24	Encephalocele	Congenital
+CM_750.26	Hydromyelia	Congenital
+CM_750.27	Diastematomyelia	Congenital
+CM_751	Congenital anomalies of eye	Congenital
+CM_751.1	Congenital disorders of the orbit	Congenital
+CM_751.11	Aplasia/Hypoplasia affecting the eye	Congenital
+CM_751.111	Cystic eyeball	Congenital
+CM_751.112	Microphthalmos	Congenital
+CM_751.113	Anophthalmos	Congenital
+CM_751.2	Congenital malformations of anterior segment of eye	Congenital
+CM_751.21	Congenital lens anomalies	Congenital
+CM_751.211	Congenital aphakia	Congenital
+CM_751.212	Spherophakia*	Congenital
+CM_751.213	Congenital cataract	Congenital
+CM_751.214	Congenital displaced lens (Ectopia lentis)	Congenital
+CM_751.215	Coloboma of lens*	Congenital
+CM_751.22	Congenital malformations of iris	Congenital
+CM_751.221	Absence of iris [Aniridia]	Congenital
+CM_751.222	Rieger's anomaly*	Congenital
+CM_751.23	Congenital corneal malformations	Congenital
+CM_751.231	Congenital corneal opacity	Congenital
+CM_751.24	Congenital anomalies of sclera	Congenital
+CM_751.241	Blue sclera*	Congenital
+CM_751.3	Congenital malformations of posterior segment of eye	Congenital
+CM_751.31	Congenital malformation of vitreous humor	Congenital
+CM_751.32	Congenital malformation of retina	Congenital
+CM_751.33	Congenital malformation of optic disc	Congenital
+CM_751.34	Congenital malformation of choroid	Congenital
+CM_751.4	Congenital glaucoma and buphthalmos	Congenital
+CM_751.5	Coloboma	Congenital
+CM_751.6	Macrophthalmosa*	Congenital
+CM_751.7	Congenital anomalies of eyelids	Congenital
+CM_751.71	Congenital malformations of eyelid	Congenital
+CM_751.711	Congenital ptosis	Congenital
+CM_751.8	Congenital anomalies of lacrimal gland	Congenital
+CM_752	Congenital malformations of ear	Congenital
+CM_752.1	Aplasia/Hypoplasia of the external ear	Congenital
+CM_752.11	Microtia	Congenital
+CM_752.12	Congenital absence of external ear [Anotia]	Congenital
+CM_752.2	Macrotia	Congenital
+CM_752.3	Accessory auricle	Congenital
+CM_752.4	Misplaced ear [Abnormal location of ears]*	Congenital
+CM_752.5	Prominent ear [Protruding ear]*	Congenital
+CM_752.6	"Congenital absence, atresia and stricture of auditory canal*"	Congenital
+CM_752.7	Congenital anomaly of middle ear	Congenital
+CM_752.8	Congenital malformation of inner ear	Congenital
+CM_753	Congenital malformations of face and neck	Congenital
+CM_753.1	Branchial anomaly	Congenital
+CM_753.2	Preauricular sinus and cyst	Congenital
+CM_753.3	Webbing of neck	Congenital
+CM_754	"Congenital malformations of tongue, mouth and pharynx"	Congenital
+CM_754.1	Oral cleft	Congenital
+CM_754.11	Cleft palate	Congenital
+CM_754.111	Cleft palate with cleft lip	Congenital
+CM_754.12	Cleft lip (without cleft palate)	Congenital
+CM_754.14	Cleft uvula [Bifid uvula]*	Congenital
+CM_754.3	Congenital malformations of mouth	Congenital
+CM_754.31	Macrostomia	Congenital
+CM_754.32	Microstomia	Congenital
+CM_754.4	Congenital malformations of lips	Congenital
+CM_754.41	Macrocheilia	Congenital
+CM_754.42	Microcheilia	Congenital
+CM_754.5	Congenital malformations of tongue	Congenital
+CM_754.52	Macroglossia	Congenital
+CM_754.6	Congenital malformations of salivary glands and ducts	Congenital
+CM_754.7	Congenital anomalies of pharynx	Congenital
+CM_754.71	Congenital pharyngeal pouch [Diverticulum of pharynx]	Congenital
+CM_755	"Congenital deformities of skull, face, and jaw"	Congenital
+CM_755.1	Congenital facial asymmetry*	Congenital
+CM_755.2	Abnormal skull shape*	Congenital
+CM_755.21	Dolichocephaly*	Congenital
+CM_755.22	Plagiocephaly*	Congenital
+CM_755.23	Craniosynostosis*	Congenital
+CM_755.3	Craniofacial dysostosis*	Congenital
+CM_755.31	Mandibulofacial dysostosis*	Congenital
+CM_755.4	Macrocephaly*	Congenital
+CM_755.5	Hypertelorism	Congenital
+CM_755.6	Congenital anomalies of nose	Congenital
+CM_755.61	Choanal atresia	Congenital
+CM_755.62	"Fissured, notched and cleft nose*"	Congenital
+CM_755.63	Agenesis and underdevelopment of nose*	Congenital
+CM_755.7	Wide cranial sutures of newborn*	Congenital
+CM_757	Congenital anomalies of upper GI tract	Congenital
+CM_757.1	Congenital malformations of esophagus	Congenital
+CM_757.11	"Congenital tracheoesophageal fistula, esophageal atresia and stenosis"	Congenital
+CM_757.111	Esophageal web*	Congenital
+CM_757.12	Congenital dilatation of esophagus*	Congenital
+CM_757.13	Congenital diverticulum of esophagus*	Congenital
+CM_757.2	Congenital malformation of stomach	Congenital
+CM_757.21	Congenital hypertrophic pyloric stenosis	Congenital
+CM_757.22	Congenital hiatus hernia	Congenital
+CM_758	Congenital malformations of digestive system	Congenital
+CM_758.1	Congenital malformations of intestine	Congenital
+CM_758.11	Meckel diverticulum	Congenital
+CM_758.12	Hirschsprung's disease	Congenital
+CM_758.13	Intestinal atresia and stenosis	Congenital
+CM_758.131	Atresia and stenosis of small intestines	Congenital
+CM_758.132	Atresia and stenosis  of large intestines	Congenital
+CM_758.14	Anomalies of intestinal fixation	Congenital
+CM_758.15	Intestinal duplication*	Congenital
+CM_758.16	Ectopic anus*	Congenital
+CM_758.17	Persistent cloaca*	Congenital
+CM_758.2	"Congenital malformations of gallbladder, bile ducts and liver"	Congenital
+CM_758.21	Biliary atresia	Congenital
+CM_758.22	Cystic liver disease	Congenital
+CM_758.3	Congenital anomalies of the pancreas	Congenital
+CM_758.31	Annular pancreas*	Congenital
+CM_760	Congenital anomalies of genital organs	Congenital
+CM_760.1	Congenital malformations of female genitalia	Congenital
+CM_760.11	Congenital malformation of ovary	Congenital
+CM_760.111	Congenital absence of ovary*	Congenital
+CM_760.112	Ovarian streak*	Congenital
+CM_760.12	Congenital malformations of fallopian tube and broad ligament	Congenital
+CM_760.13	Congenital anomalies of uterus and cervix	Congenital
+CM_760.131	Aplasia and hypoplasia of uterus	Congenital
+CM_760.132	Doubling of uterus	Congenital
+CM_760.133	Bicornate uterus	Congenital
+CM_760.134	Unicornate uterus	Congenital
+CM_760.135	Arcuate uterus	Congenital
+CM_760.15	Congenital malformations of vagina	Congenital
+CM_760.151	Vaginal agenesis	Congenital
+CM_760.152	Doubling of vagina/Vaginal septum	Congenital
+CM_760.153	Imperforate hymen	Congenital
+CM_760.16	Congenital malformations of vulva*	Congenital
+CM_760.161	Fusion of labia*	Congenital
+CM_760.17	"Embryonic cyst of cervix, vagina, and external female genitalia"	Congenital
+CM_760.18	Congenital malformation of clitoris*	Congenital
+CM_760.2	Congenital congenital malformations of male genital organs	Congenital
+CM_760.21	Congenital malformations of testis and scrotum	Congenital
+CM_760.211	Undescended testis [Cryptorchidism]	Congenital
+CM_760.212	Retractile testis	Congenital
+CM_760.213	Ectopic testis*	Congenital
+CM_760.214	Aplasia/hypoplasia of testis*	Congenital
+CM_760.215	Scrotal transposition	Congenital
+CM_760.22	Congenital malformations of penis	Congenital
+CM_760.221	Hypospadias	Congenital
+CM_760.222	Congenital chordee	Congenital
+CM_760.223	Hypoplasia of penis	Congenital
+CM_760.224	Hidden penis	Congenital
+CM_760.225	Congenital torsion of penis*	Congenital
+CM_760.226	Curvature of penis (lateral)*	Congenital
+CM_760.227	Epispadias	Congenital
+CM_760.25	"Congenital malformations of vas deferens, epididymis, seminal vesicles and prostate*"	Congenital
+CM_760.26	Congenital hydrocele	Congenital
+CM_760.3	Indeterminate sex and hermaphroditism	Congenital
+CM_761	Congenital malformations of the urinary system	Congenital
+CM_761.1	Congenital malformation of kidney	Congenital
+CM_761.11	Renal hypoplasia/aplasia	Congenital
+CM_761.111	Renal agenesis*	Congenital
+CM_761.112	Renal hypoplasia*	Congenital
+CM_761.12	Renal dysplasia	Congenital
+CM_761.13	Cystic kidney disease	Congenital
+CM_761.131	Medullary cystic kidney	Congenital
+CM_761.16	Accessory kidney*	Congenital
+CM_761.17	"Lobulated, fused and horseshoe kidney*"	Congenital
+CM_761.18	Ectopic kidney*	Congenital
+CM_761.19	Hyperplastic and giant kidney*	Congenital
+CM_761.2	Congenital malformations of ureter and renal pelvis	Congenital
+CM_761.21	"Obstructive defects of renal pelvis and ureter, congenital"	Congenital
+CM_761.211	Congenital hydronephrosis*	Congenital
+CM_761.212	Congenital ureterocele	Congenital
+CM_761.23	Congenital megaureter*	Congenital
+CM_761.24	Agenesis of ureter*	Congenital
+CM_761.25	Duplication of ureter*	Congenital
+CM_761.26	Malposition of ureter*	Congenital
+CM_761.3	Congenital malformations of bladder and urethra	Congenital
+CM_761.31	Bladder exstrophy	Congenital
+CM_761.32	Congenital posterior urethral valves*	Congenital
+CM_761.33	Congenital atresia and stenosis of urethra and bladder neck	Congenital
+CM_761.34	Abnormality of the urachus	Congenital
+CM_761.35	Congenital absence of bladder and urethra*	Congenital
+CM_762	Congenital malformations of respiratory system	Congenital
+CM_762.1	Congenital malformations of larynx	Congenital
+CM_762.11	Laryngeal web	Congenital
+CM_762.12	Congenital subglottic stenosis*	Congenital
+CM_762.13	Laryngeal hypoplasia*	Congenital
+CM_762.14	Laryngocele*	Congenital
+CM_762.15	Congenital laryngomalacia*	Congenital
+CM_762.2	Congenital malformations of trachea and bronchus*	Congenital
+CM_762.3	Congenital malformations of lung	Congenital
+CM_762.31	Congenital cystic lung	Congenital
+CM_762.32	Congenital bronchiectasis	Congenital
+CM_762.33	Congenital hypoplasia and dysplasia of lung	Congenital
+CM_762.34	Accessory lobe of lung*	Congenital
+CM_762.35	Sequestration of lung [Pulmonary sequestration]*	Congenital
+CM_763	Congenital anomalies of the heart	Congenital
+CM_763.1	Congenital malformations of great arteries	Congenital
+CM_763.11	Common arterial trunk [Truncus arteriosus]	Congenital
+CM_763.12	Transposition of great vessels [TGA]	Congenital
+CM_763.13	Patent ductus arteriosus	Congenital
+CM_763.14	Congenital anomalies of aorta	Congenital
+CM_763.141	Coarctation of aorta	Congenital
+CM_763.142	Interruption of aortic arch	Congenital
+CM_763.143	Congenital atresia and stenosis of aorta	Congenital
+CM_763.144	Aplasia or hypoplasia of aorta*	Congenital
+CM_763.145	Congenital dilation or aneurysm of aorta*	Congenital
+CM_763.146	Vascular ring of aorta*	Congenital
+CM_763.147	Right aortic arch*	Congenital
+CM_763.15	"Anomalies of pulmonary artery, congenital"	Congenital
+CM_763.151	Pulmonary artery coarctation and atresia	Congenital
+CM_763.152	Stenosis of pulmonary artery*	Congenital
+CM_763.153	Congenital pulmonary arteriovenous malformation	Congenital
+CM_763.16	Double outlet right ventricle	Congenital
+CM_763.17	Double outlet left ventricle*	Congenital
+CM_763.18	Congenital Pulmonary infundibular stenosis	Congenital
+CM_763.2	Congenital malformations of heart valves	Congenital
+CM_763.21	Congenital anomalies of pulmonary valve	Congenital
+CM_763.211	Congenital pulmonary valve atresia	Congenital
+CM_763.212	Congenital pulmonary valve stenosis	Congenital
+CM_763.213	Congenital pulmonary valve insufficiency*	Congenital
+CM_763.22	Congenital malformations of tricuspid valve	Congenital
+CM_763.221	Congenital tricuspid stenosis*	Congenital
+CM_763.222	Ebstein anomaly of the tricuspid valve	Congenital
+CM_763.23	Congenital malformation of aortic and mitral valves	Congenital
+CM_763.231	Congenital stenosis of aortic valve	Congenital
+CM_763.232	Congenital insufficiency of aortic valve	Congenital
+CM_763.233	Congenital mitral stenosis	Congenital
+CM_763.234	Congenital mitral insufficiency	Congenital
+CM_763.24	Hypoplastic right heart syndrome*	Congenital
+CM_763.3	Congenital malformations of cardiac chambers and connections	Congenital
+CM_763.31	Ventricular septal defect	Congenital
+CM_763.32	Atrial septal defect	Congenital
+CM_763.321	Patent foramen ovale*	Congenital
+CM_763.33	Atrioventricular septal defect	Congenital
+CM_763.34	Cor triatriatum	Congenital
+CM_763.35	Aortopulmonary septal defect*	Congenital
+CM_763.36	Common ventricle or double inlet ventricle	Congenital
+CM_763.4	Tetralogy of Fallot	Congenital
+CM_763.5	Congenital subaortic stenosis	Congenital
+CM_763.6	Anomalous pulmonary venous return	Congenital
+CM_763.7	Hypoplastic left heart syndrome	Congenital
+CM_763.8	Congenital heart block	Congenital
+CM_763.9	Congenital anomaly of the coronary artery	Congenital
+CM_764	Congenital malformations of circulatory system (other than heart)	Congenital
+CM_764.1	Congenital anomalies of great veins	Congenital
+CM_764.11	Persistent left superior vena cava*	Congenital
+CM_764.12	Congenital anomaly of gastrointestinal vessel [Anomalous portal venous connection]	Congenital
+CM_764.2	Congenital absence and hypoplasia of umbilical artery	Congenital
+CM_764.3	Congenital malformations of renal artery	Congenital
+CM_764.5	Congenital arteriovenous malformation*	Congenital
+CM_765	Congenital deformities of hip	Congenital
+CM_765.1	Congenital dislocation of hip	Congenital
+CM_765.11	"Congenital dislocation of hip, bilateral"	Congenital
+CM_765.2	"Congenital coxa valga, congenital"	Congenital
+CM_765.3	"Congenital coxa vara, congenital"	Congenital
+CM_766	Congenital deformities of feet	Congenital
+CM_766.1	Congenital talipes varus	Congenital
+CM_766.11	Congenital talipes equinovarus	Congenital
+CM_766.12	Congenital metatarsus primus varus	Congenital
+CM_766.13	Congenital pes cavus	Congenital
+CM_766.2	Congenital talipes valgus	Congenital
+CM_766.21	Congenital talipes calcaneovalgus	Congenital
+CM_766.22	Congenital pes planus	Congenital
+CM_767	Congenital anomalies of limbs	Congenital
+CM_767.1	Abnormal digit morphology	Congenital
+CM_767.11	Polydactyly	Congenital
+CM_767.12	Syndactyly	Congenital
+CM_767.2	Reduction defects of limb	Congenital
+CM_767.21	Reduction defects of upper limb	Congenital
+CM_767.22	Reduction defects of lower limb	Congenital
+CM_767.3	Congenital deformity of knee	Congenital
+CM_767.6	Bowing of the long bones	Congenital
+CM_768	Congenital deformities of chest and bony thorax	Congenital
+CM_768.1	Chest wall deforities	Congenital
+CM_768.11	Pectus excavatum	Congenital
+CM_768.12	Pectus carinatum	Congenital
+CM_768.2	Congenital anomalies of ribs and sternum	Congenital
+CM_768.21	Cervical rib	Congenital
+CM_769	Congenital malformations of spine	Congenital
+CM_769.1	Klippel-Feil syndrome	Congenital
+CM_769.2	Congenital scoliosis*	Congenital
+CM_769.3	Congenital kyphosis*	Congenital
+CM_769.4	Congenital lordosis*	Congenital
+CM_769.7	Congenital spondylolisthesis	Congenital
+CM_770	Other congenital malformations of musculoskeletal system	Congenital
+CM_770.1	Congenital malformations of diaphragm	Congenital
+CM_770.11	Congenital diaphragmatic hernia*	Congenital
+CM_770.2	Congenital malformations of abdominal wall	Congenital
+CM_770.21	Exomphalos [Omphalocele]	Congenital
+CM_770.22	Gastroschisis	Congenital
+CM_770.23	Prune belly syndrome	Congenital
+CM_770.3	Congenital musculoskeletal deformities of sternocleidomastoid muscle	Congenital
+CM_770.4	Arthrogryposis multiplex congenita*	Congenital
+CM_770.5	Congenital osteodystrophies	Congenital
+CM_771	Congenital malformations of integument	Congenital
+CM_771.1	Congenital malformation of the skin	Congenital
+CM_771.11	Congenital pigmentary anomalies of skin	Congenital
+CM_771.14	Congenital non-neoplastic nevus	Congenital
+CM_771.2	Congenital anomalies of hair	Congenital
+CM_771.3	Congenital anomalies of nails	Congenital
+CM_771.4	Congenital anomalies of breast	Congenital
+CM_772	Congenital disorder of endocrine glands	Congenital
+CM_772.1	Congenital malformations of endocrine glands	Congenital
+CM_772.11	Congenital anomalies of adrenal gland	Congenital
+CM_772.2	Congenital hypothyroidism	Congenital
+CM_772.3	Congenital iodine-deficiency syndrome*	Congenital
+CM_773	Congenital malformations of spleen	Congenital
+CM_773.1	Asplenia*	Congenital
+CM_774	Situs inversus and related disorders	Congenital
+CM_774.1	Situs inversus	Congenital
+CM_774.2	Malposition of heart and cardiac apex	Congenital
+CM_775	Conjoined twins	Congenital
+CM_776	Multiple congenital malformations	Congenital
+CM_777	Congenital malformation syndromes attributed to exogenous causes	Congenital
+CM_777.1	Fetal alcohol syndrome*	Congenital
+CM_778	"Other congenital malformations, NEC"	Congenital
+SS_800	Chest pain	Symptoms
+SS_800.1	Chest pain on breathing	Symptoms
+SS_800.11	Pleurodynia*	Symptoms
+SS_800.2	Precordial pain	Symptoms
+SS_800.3	Intercostal pain*	Symptoms
+SS_805	Fever	Symptoms
+SS_806	Chills (without fever)	Symptoms
+SS_807	Malaise and fatigue	Symptoms
+SS_807.1	Chronic fatigue syndrome	Symptoms
+SS_807.11	Postviral fatigue syndrome*	Symptoms
+SS_807.2	Weakness	Symptoms
+SS_807.21	Muscle weakness (generalized)	Symptoms
+SS_807.3	Post COVID-19 condition*	Symptoms
+SS_808	Syncope and collapse	Symptoms
+SS_808.1	Carotid sinus syncope	Symptoms
+SS_809	Pain	Symptoms
+SS_809.1	Acute pain	Symptoms
+SS_809.2	Chronic pain	Symptoms
+SS_809.21	Chronic pain syndrome	Symptoms
+SS_809.22	Central pain syndrome	Symptoms
+SS_809.3	Pain in limb	Symptoms
+SS_809.31	Pain in arm*	Symptoms
+SS_809.32	Pain in leg*	Symptoms
+SS_809.33	Pain in hand and fingers*	Symptoms
+SS_809.34	Pain in foot and toes*	Symptoms
+SS_810	Shock	Symptoms
+SS_810.1	Septic shock	Symptoms
+SS_810.2	Cardiogenic shock	Symptoms
+SS_810.3	Hypovolemic shock*	Symptoms
+SS_811	"Hypothermia, not associated with low environmental temperature"	Symptoms
+SS_812	Edema	Symptoms
+SS_812.1	Generalized edema*	Symptoms
+SS_812.2	Angioneurotic edema	Symptoms
+SS_813	Clubbing of fingers	Symptoms
+SS_814	Jaundice	Symptoms
+SS_815	Symptoms and signs concerning food and fluid intake	Symptoms
+SS_817	Motion sickness	Symptoms
+SS_819	General symptoms and other findings	Symptoms
+SS_820	Elevated erythrocyte sedimentation rate	Symptoms
+SS_821	Abnormality of red blood cells	Symptoms
+SS_821.1	Precipitous drop in hematocrit	Symptoms
+SS_822	"Other and nonspecific abnormal cytological, histological and immunological findings"	Symptoms
+SS_822.8	Abnormal tumor markers	Symptoms
+SS_822.81	Elevated carcinoembryonic antigen [CEA]	Symptoms
+SS_822.82	Elevated cancer antigen 125 [CA 125]	Symptoms
+SS_823	Abnormal serum enzyme levels	Symptoms
+SS_823.1	Nonspecific elevation of levels of transaminase or lactic acid dehydrogenase [LDH]	Symptoms
+SS_823.2	Abnormal levels of other serum enzymes	Symptoms
+SS_824	Other abnormalities of plasma proteins*	Symptoms
+SS_824.1	Abnormality of albumin*	Symptoms
+SS_824.2	Abnormality of globulin*	Symptoms
+SS_824.3	Abnormality of alphafetoprotein*	Symptoms
+SS_825	Elevated C-reactive protein (CRP)	Symptoms
+SS_826	Other abnormal immunological findings in serum	Symptoms
+SS_826.1	Nonspecific reaction to test for tuberculosis	Symptoms
+SS_826.2	Inconclusive laboratory evidence of human immunodeficiency virus [HIV]	Symptoms
+SS_826.3	Raised antibody titer*	Symptoms
+SS_826.4	Other and unspecified nonspecific immunological findings	Symptoms
+SS_827	Toxicology findings	Symptoms
+SS_827.1	Finding of alcohol in blood	Symptoms
+SS_829	Abnormal findings on examination of blood	Symptoms
+SS_829.1	Abnormal blood-gas level	Symptoms
+SS_829.2	Abnormal level of blood mineral*	Symptoms
+SS_829.3	Abnormal plasma viscosity*	Symptoms
+SS_830	Proteinuria	Symptoms
+SS_831	Glycosuria	Symptoms
+SS_832	Other abnormal findings in urine	Symptoms
+SS_832.1	Chyluria	Symptoms
+SS_832.2	Myoglobinuria	Symptoms
+SS_832.4	Hemoglobinuria	Symptoms
+SS_832.5	Acetonuria	Symptoms
+SS_832.6	Pyuria*	Symptoms
+SS_832.7	Hypocitraturia*	Symptoms
+SS_832.8	Hyperoxaluria*	Symptoms
+SS_832.9	Hypercalciuria*	Symptoms
+SS_834	Abnormal cytological findings in specimens from genital organs	Symptoms
+SS_834.1	Abnormal Papanicolaou smear	Symptoms
+SS_834.3	High risk human papillomavirus (HPV) DNA test positive	Symptoms
+SS_835	Cytology and pathology findings	Symptoms
+SS_835.1	Nonspecific abnormal findings in cerebrospinal fluid	Symptoms
+SS_840	Allergy	Symptoms
+SS_840.1	Food allergy	Symptoms
+SS_840.11	Peanut allergy	Symptoms
+SS_840.12	Seafood allergy	Symptoms
+SS_840.13	Allergy to fruits and vegetables	Symptoms
+SS_840.14	Tree nut allergy	Symptoms
+SS_840.15	Fish allergy	Symptoms
+SS_840.16	Allergy to food additives	Symptoms
+SS_840.17	Milk allergy	Symptoms
+SS_840.18	Egg allergy	Symptoms
+SS_840.2	Allergy to insects	Symptoms
+SS_840.4	Latex allergy	Symptoms
+SS_840.5	Allergy to radiographic dye	Symptoms
+SS_840.6	Drug and medical agent allergy	Symptoms
+SS_840.61	Allergy to other anti-infective agents	Symptoms
+SS_840.611	Penicillin allergy	Symptoms
+SS_840.612	Allergy to antibiotic agent (excluding penicillin)	Symptoms
+SS_840.613	Allergy to sulfonamides	Symptoms
+SS_840.62	Allergy to anesthetic agent	Symptoms
+SS_840.63	Allergy to narcotic agent	Symptoms
+SS_840.64	Allergy to analgesic agent	Symptoms
+SS_840.65	Allergy to serum and vaccine	Symptoms
+SS_840.8	Allergies related to other diseases/symptoms	Symptoms
+SS_840.9	Anaphylactic reaction	Symptoms
+SS_844	Wheelchair dependence	Symptoms
+SS_847	Transplated organ	Symptoms
+SS_847.1	Heart transplant	Symptoms
+SS_847.2	Kidney transplant	Symptoms
+SS_847.3	Liver transplant	Symptoms
+SS_847.4	Lung transplant	Symptoms
+SS_847.5	Pancreas transplant	Symptoms
+SS_847.6	Intestine transplant	Symptoms
+SS_847.7	Bone marrow transplant	Symptoms
+SS_847.8	Stem cell transplant	Symptoms
+SS_848	Nonspecific abnormal findings of other body structures	Symptoms
+SS_849	Lack of expected normal physiological development in childhood	Symptoms
+SS_849.1	Failure to thrive in childhood	Symptoms
+SS_849.3	Short stature	Symptoms
+SS_849.4	Arrest of bone development or growth	Symptoms
+NB_850	Disorders of newborn related to slow fetal growth and fetal malnutrition	Neonatal
+NB_850.1	Newborn light or small for gestational age	Neonatal
+NB_850.2	Newborn affected by fetal (intrauterine) malnutrition not light or small for gestational age	Neonatal
+NB_850.3	Newborn affected by slow intrauterine growth	Neonatal
+NB_851	Exceptionally large newborn baby	Neonatal
+NB_853	Cardiovascular disorders originating in the perinatal period	Neonatal
+NB_853.1	Neonatal cardiac failure*	Neonatal
+NB_853.2	Neonatal cardiac dysrhythmia	Neonatal
+NB_853.21	Neonatal tachycardia	Neonatal
+NB_853.22	Neonatal bradycardia	Neonatal
+NB_853.3	Neonatal hypertension*	Neonatal
+NB_853.4	Pulmonary hypertension of newborn*	Neonatal
+NB_853.5	Cardiac arrest of newborn	Neonatal
+NB_853.6	Persistent fetal circulation	Neonatal
+NB_854	Respiratory conditions of fetus and newborn	Neonatal
+NB_854.1	Respiratory distress of newborn	Neonatal
+NB_854.11	Respiratory distress syndrome of newborn	Neonatal
+NB_854.12	Transient tachypnea of newborn	Neonatal
+NB_854.2	Interstitial emphysema and related conditions of newborn	Neonatal
+NB_854.4	Atelectasis of newborn	Neonatal
+NB_854.5	Cyanotic attacks of newborn	Neonatal
+NB_854.6	Respiratory failure of newborn	Neonatal
+NB_854.7	Chronic respiratory disease arising in the perinatal period	Neonatal
+NB_854.71	Bronchopulmonary dysplasia originating in the perinatal period*	Neonatal
+NB_854.9	Apnea of newborn	Neonatal
+NB_856	Infections in newborn	Neonatal
+NB_856.1	Congenital viral diseases	Neonatal
+NB_856.11	Congenital cytomegalovirus infection	Neonatal
+NB_856.2	Bacterial infection of newborn	Neonatal
+NB_856.21	Bacterial sepsis of newborn	Neonatal
+NB_856.3	Neonatal candidiasis	Neonatal
+NB_856.4	Omphalitis of newborn	Neonatal
+NB_856.5	Neonatal urinary tract infection	Neonatal
+NB_856.6	Neonatal conjunctivitis and dacryocystitis	Neonatal
+NB_856.7	Congenital syphilis	Neonatal
+NB_856.8	Congenital pneumonia	Neonatal
+NB_857	Neonatal hemorrhages	Neonatal
+NB_857.1	Intracranial nontraumatic hemorrhage of newborn	Neonatal
+NB_857.11	Intraventricular nontraumatic hemorrhage of newborn [IVH]	Neonatal
+NB_857.2	Neonatal gastrointestinal hemorrhage	Neonatal
+NB_857.3	Neonatal cutaneous hemorrhage	Neonatal
+NB_857.4	Umbilical hemorrhage of newborn	Neonatal
+NB_857.5	Pulmonary hemorrhage in infants	Neonatal
+NB_857.51	Acute idiopathic pulmonary hemorrhage in infants	Neonatal
+NB_857.8	Newborn affected by fetal blood loss	Neonatal
+NB_858	Hemolytic Disease of the Newborn	Neonatal
+NB_858.1	Rh isoimmunization of newborn	Neonatal
+NB_858.2	ABO isoimmunization of newborn	Neonatal
+NB_859	Perinatal jaundice	Neonatal
+NB_859.1	Neonatal jaundice associated with preterm delivery	Neonatal
+NB_859.2	Neonatal jaundice from hepatocellular damage	Neonatal
+NB_859.3	Neonatal jaundice due to excessive hemolysis	Neonatal
+NB_860	Hematological disorders of newborn	Neonatal
+NB_860.1	Neonatal disorders of coagulation	Neonatal
+NB_860.11	Disseminated intravascular coagulation of newborn	Neonatal
+NB_860.12	Transient neonatal thrombocytopenia	Neonatal
+NB_860.2	Polycythemia neonatorum	Neonatal
+NB_860.3	Anemia in newborn	Neonatal
+NB_860.4	Transient neonatal neutropenia	Neonatal
+NB_861	Transitory disorders of carbohydrate metabolism specific to newborn	Neonatal
+NB_861.1	Neonatal diabetes mellitus	Neonatal
+NB_861.2	Neonatal hypoglycemia	Neonatal
+NB_862	Transitory neonatal disorders of calcium and magnesium metabolism	Neonatal
+NB_863	Transitory neonatal endocrine disorders	Neonatal
+NB_864	Transitory neonatal electrolyte and metabolic disturbances	Neonatal
+NB_864.1	Neonatal metabolic acidemia	Neonatal
+NB_864.2	Alkalosis of newborn*	Neonatal
+NB_864.3	Transitory electrolyte disturbances of newborn*	Neonatal
+NB_864.31	Hyperchloremia of newborn*	Neonatal
+NB_864.32	Hypochloremia of newborn*	Neonatal
+NB_864.4	Transitory tyrosinemia of newborn*	Neonatal
+NB_864.5	Transitory hyperammonemia of newborn*	Neonatal
+NB_865	Neonatal disorders of digestive system	Neonatal
+NB_865.1	Intestinal obstruction of newborn	Neonatal
+NB_865.11	Meconium plug syndrome	Neonatal
+NB_865.12	Transitory ileus of newborn	Neonatal
+NB_865.2	Necrotizing enterocolitis [NEC] in newborn	Neonatal
+NB_865.3	Perinatal intestinal perforation	Neonatal
+NB_865.5	Noninfective neonatal diarrhea*	Neonatal
+NB_865.6	Congenital cirrhosis (of liver)*	Neonatal
+NB_865.7	Newborn esophageal reflux*	Neonatal
+NB_866	Disturbances of temperature regulation of newborn	Neonatal
+NB_866.1	Hypothermia of newborn	Neonatal
+NB_868	Conditions of integument specific to newborn	Neonatal
+NB_868.1	Sclerema neonatorum	Neonatal
+NB_868.2	Neonatal erythema toxicum*	Neonatal
+NB_868.3	Hydrops fetalis not due to hemolytic disease	Neonatal
+NB_868.4	Edema specific to newborn	Neonatal
+NB_868.5	Breast engorgement in newborn	Neonatal
+NB_868.7	Umbilical granuloma*	Neonatal
+NB_870	Disturbances of cerebral status of newborn	Neonatal
+NB_870.1	Convulsions of newborn	Neonatal
+NB_870.2	Neonatal cerebral ischemia*	Neonatal
+NB_870.3	Acquired periventricular cysts of newborn*	Neonatal
+NB_870.4	Neonatal cerebral leukomalacia	Neonatal
+NB_871	Feeding problems of newborn	Neonatal
+NB_871.1	Vomiting of newborn	Neonatal
+NB_871.2	Failure to thrive in newborn	Neonatal
+NB_871.4	Ankyloglossia	Neonatal
+NB_872	Other and ill-defined conditions originating in the perinatal period	Neonatal
+NB_872.1	Disorders of muscle tone of newborn*	Neonatal
+NB_872.11	Congenital hypertonia*	Neonatal
+NB_872.12	Congenital hypotonia*	Neonatal
+NB_872.13	Transient neonatal myasthenia gravis	Neonatal
+NB_872.2	Congenital renal failure*	Neonatal
+NB_872.4	Delayed separation of umbilical cord	Neonatal
+NB_872.5	Meconium staining	Neonatal
+NB_873	Retinopathy of prematurity	Neonatal
+NB_873.1	"Retinopathy of prematurity, stage 0"	Neonatal
+NB_873.2	"Retinopathy of prematurity, stage 1"	Neonatal
+NB_873.3	"Retinopathy of prematurity, stage 2"	Neonatal
+NB_873.4	"Retinopathy of prematurity, stage 3"	Neonatal
+NB_873.5	"Retinopathy of prematurity, stage 4"	Neonatal
+NB_873.6	"Retinopathy of prematurity, stage 5"	Neonatal
+NB_874	Neonatal obstruction of nasolacrimal duct	Neonatal
+NB_875	Newborn affected by maternal conditions	Neonatal
+NB_876	Newborn affected by maternal complications of pregnancy	Neonatal
+NB_877	"Newborn affected by complications of placenta, cord and membranes"	Neonatal
+NB_878	Newborn affected by other complications of labor and delivery	Neonatal
+NB_879	Newborn affected by noxious substances transmitted via placenta or breast milk	Neonatal
+NB_880	Birth trauma	Neonatal
+NB_881	Neonatal aspiration	Neonatal
+NB_882	"Intrauterine hypoxia, birth asphyxia and fetal distress"	Neonatal
+NB_882.1	Hypoxic ischemic encephalopathy [HIE]	Neonatal
+NB_885	Weeks gestation	Neonatal
+NB_885.1	Extremely preterm (<= 28 weeks)	Neonatal
+NB_885.11	"Extremely preterm, <24 weeks"	Neonatal
+NB_885.12	"Extremely preterm, 24 weeks"	Neonatal
+NB_885.13	"Extremely preterm, 25-26 weeks"	Neonatal
+NB_885.131	"Extremely preterm, 25 weeks*"	Neonatal
+NB_885.132	"Extremely preterm, 26 weeks*"	Neonatal
+NB_885.14	"Extremely preterm, 27-28 weeks"	Neonatal
+NB_885.141	"Extremely preterm, 27 weeks*"	Neonatal
+NB_885.142	"Extremely preterm, 28 weeks*"	Neonatal
+NB_885.2	Very preterm (29 to 32 weeks)*	Neonatal
+NB_885.21	"Very preterm, 29-30 weeks"	Neonatal
+NB_885.211	"Very preterm, 29 weeks*"	Neonatal
+NB_885.212	"Very preterm, 30 weeks*"	Neonatal
+NB_885.22	"Very preterm, 31-32 weeks"	Neonatal
+NB_885.221	"Very preterm, 31 weeks*"	Neonatal
+NB_885.222	"Very preterm, 32 weeks*"	Neonatal
+NB_885.3	Moderate to late preterm (33 to 37 weeks)	Neonatal
+NB_885.31	"Moderate to late preterm, 33-34 weeks"	Neonatal
+NB_885.311	"Moderate to late preterm, 33 weeks*"	Neonatal
+NB_885.312	"Moderate to late preterm, 34 weeks*"	Neonatal
+NB_885.32	"Moderate to late preterm, 35-36 weeks"	Neonatal
+NB_885.321	"Moderate to late preterm, 35 weeks*"	Neonatal
+NB_885.322	"Moderate to late preterm, 36 weeks*"	Neonatal
+NB_885.5	Post-term infant (>40 weeks)	Neonatal
+NB_886	Birthweight	Neonatal
+NB_886.1	"Extremely low birthweight (<1,000 g)"	Neonatal
+NB_886.11	"Extremely low birthweight, <500 grams"	Neonatal
+NB_886.12	"Extremely low birthweight, 500-749 grams"	Neonatal
+NB_886.13	"Extremely low birthweight, 750-999 grams"	Neonatal
+NB_886.2	"Very low birthweight (1,000 - 1,500 g)"	Neonatal
+NB_886.21	"Very low birthweight, 1,000-1,249 grams"	Neonatal
+NB_886.22	"Very low birthweight, 1,250-1,499 grams"	Neonatal
+NB_886.3	"Low birthweight (1,500 - 2,500 g)"	Neonatal
+NB_886.31	"Low birthweight, 1,500-1,749 grams"	Neonatal
+NB_886.32	"Low birthweight, 1,750-1,999 grams"	Neonatal
+NB_886.33	"Low birthweight, 2,000-2,499 grams"	Neonatal
+NB_886.4	"Birthweight 2,500+ grams"	Neonatal
+NB_887	Abnormal findings on neonatal screening	Neonatal
+NB_887.1	Abnormal findings on neonatal hearing screening*	Neonatal
+NB_889	Nonspecific symptoms peculiar to infancy	Neonatal
+NB_889.1	Fussy infant	Neonatal
+NB_889.2	Apparent life threatening event in infant (ALTE)	Neonatal
+NB_889.4	Teething syndrome	Neonatal
+PP_900	Spontaneous abortion or history of recurrent pregnancy loss	Pregnancy
+PP_900.1	Spontaneous abortion	Pregnancy
+PP_900.2	Recurrent pregnancy loss	Pregnancy
+PP_901	Abnormal products of conception	Pregnancy
+PP_901.1	Ectopic pregnancy	Pregnancy
+PP_901.11	Abdominal pregnancy	Pregnancy
+PP_901.12	Tubal pregnancy	Pregnancy
+PP_901.13	Ovarian pregnancy	Pregnancy
+PP_901.2	Hydatidiform mole	Pregnancy
+PP_901.3	Missed abortion	Pregnancy
+PP_901.4	Papyraceous fetus	Pregnancy
+PP_902	Intrauterine death	Pregnancy
+PP_903	Preterm labor (including history of)	Pregnancy
+PP_903.1	Preterm labor with preterm delivery	Pregnancy
+PP_903.2	Threatened premature labor	Pregnancy
+PP_904	Bleeding in pregnancy	Pregnancy
+PP_904.1	Hemorrhage in early pregnancy	Pregnancy
+PP_904.11	Threatened abortion	Pregnancy
+PP_904.2	Spotting complicating pregnancy	Pregnancy
+PP_904.3	Antepartum hemorrhage	Pregnancy
+PP_905	Premature rupture of membranes	Pregnancy
+PP_906	Cervical shortening and incompetence	Pregnancy
+PP_907	Placental disorders	Pregnancy
+PP_907.1	Placenta previa	Pregnancy
+PP_907.2	Low lying placenta*	Pregnancy
+PP_907.3	Premature separation of placenta [abruptio placentae]	Pregnancy
+PP_907.4	Placenta accreta*	Pregnancy
+PP_907.6	Malformation of placenta*	Pregnancy
+PP_907.7	Placental infarction*	Pregnancy
+PP_907.8	Placental transfusion syndromes*	Pregnancy
+PP_908	"Edema, proteinuria and hypertensive disorders in pregnancy, childbirth and the puerperium"	Pregnancy
+PP_908.1	Preeclampsia and eclampsia	Pregnancy
+PP_908.12	Severe pre-eclampsia	Pregnancy
+PP_908.13	Eclampsia	Pregnancy
+PP_908.14	HELLP syndrome*	Pregnancy
+PP_908.2	"Pre-existing hypertension complicating pregnancy, childbirth and the puerperium"	Pregnancy
+PP_908.3	Gestational [pregnancy-induced] hypertension without significant proteinuria	Pregnancy
+PP_908.4	Gestational edema and proteinuria*	Pregnancy
+PP_909	"Diabetes mellitus or abnormal glucose in pregnancy, childbirth, and the puerperium"	Pregnancy
+PP_909.1	Gestational diabetes mellitus*	Pregnancy
+PP_909.2	Pre-existing diabetes mellitus in pregnancy*	Pregnancy
+PP_909.3	Abnormal glucose complicating pregnancy	Pregnancy
+PP_910	Obesity or excessive weight gain in pregnancy	Pregnancy
+PP_910.1	Excessive weight gain in pregnancy	Pregnancy
+PP_911	Excessive vomiting in pregnancy	Pregnancy
+PP_911.1	Hyperemesis gravidarum	Pregnancy
+PP_912	Venous complications in pregnancy	Pregnancy
+PP_912.1	Varicose veins in pregnancy	Pregnancy
+PP_912.2	Thrombotic conditions of pregnancy	Pregnancy
+PP_912.21	Deep phlebothrombosis [DVT] of pregnancy	Pregnancy
+PP_913	Obstetrical embolism	Pregnancy
+PP_914	Anemia in pregnancy	Pregnancy
+PP_916	Maternal infections and carrier state in pregnancy	Pregnancy
+PP_916.1	Infections of genitourinary tract in pregnancy	Pregnancy
+PP_916.2	"Viral diseases complicating pregnancy, childbirth, or the puerperium"	Pregnancy
+PP_916.21	Viral hepatitis complicating pregnancy*	Pregnancy
+PP_916.4	Streptococcus B carrier	Pregnancy
+PP_916.6	Syphilis complicating pregnancy	Pregnancy
+PP_916.7	Gonorrhea complicating pregnancy	Pregnancy
+PP_917	Liver and biliary tract disorders in pregnancy	Pregnancy
+PP_918	Pregnancy related renal disease	Pregnancy
+PP_919	Peripheral neuritis in pregnancy	Pregnancy
+PP_920	Problems associated with amniotic cavity and membranes	Pregnancy
+PP_920.1	Polyhydramnios	Pregnancy
+PP_920.2	Oligohydramnios	Pregnancy
+PP_920.3	Infection of amniotic cavity	Pregnancy
+PP_920.31	Chorioamnionitis*	Pregnancy
+PP_922	"Endocrine, nutritional and metabolic diseases complicating pregnancy"	Pregnancy
+PP_922.1	Low weight gain in pregnancy*	Pregnancy
+PP_922.2	"Thyroid dysfunction complicating pregnancy, childbirth, or the puerperium"	Pregnancy
+PP_923	Maternal hypotension syndrome	Pregnancy
+PP_924	"Cardiovascular disorders complicating pregnancy, childbirth, or the puerperium"	Pregnancy
+PP_926	"Mental disorders complicating pregnancy, childbirth and the puerperium"	Pregnancy
+PP_926.1	Postpartum mood disturbance*	Pregnancy
+PP_926.11	Postpartum depression*	Pregnancy
+PP_927	Drugs and alcohol during pregnancy	Pregnancy
+PP_927.1	Alcohol use during pregnancy*	Pregnancy
+PP_927.2	Tobacco use during pregnancy	Pregnancy
+PP_927.3	Other drug use during pregnancy	Pregnancy
+PP_928	Poor fetal growth and uterine size date discrepancy	Pregnancy
+PP_928.1	Uterine size date discrepancy	Pregnancy
+PP_928.2	"Placental insufficiency, known or suspected*"	Pregnancy
+PP_929	Excessive fetal growth	Pregnancy
+PP_930	Maternal care for abnormality of pelvic organs	Pregnancy
+PP_930.3	Abnormalities of gravid uterus	Pregnancy
+PP_930.31	Maternal care for retroversion of gravid uterus	Pregnancy
+PP_932	Known or suspected fetal abnormality affecting management of mother	Pregnancy
+PP_932.1	Abnormality in fetal heart rate or rhythm	Pregnancy
+PP_932.11	Abnormality in fetal heart rate and rhythm complicating labor and delivery*	Pregnancy
+PP_932.2	Central nervous system malformation in fetus affecting management of mother	Pregnancy
+PP_932.3	Genetic disease in fetus affecting management of mother	Pregnancy
+PP_932.4	"Decreased fetal movements, affecting management of mother"	Pregnancy
+PP_932.5	Fetal hematologic conditions	Pregnancy
+PP_932.6	Maternal care for hydrops fetalis*	Pregnancy
+PP_935	Rhesus isoimmunization affecting management of mother	Pregnancy
+PP_937	Abnormal findings on antenatal screening of mother	Pregnancy
+PP_938	"Other conditions or status of the mother complicating pregnancy, childbirth, or the puerperium"	Pregnancy
+PP_938.1	Pruritic urticarial papules and plaques of pregnancy (PUPPP)*	Pregnancy
+PP_940	Malposition and malpresentation of fetus	Pregnancy
+PP_940.1	Maternal care for breech presentation	Pregnancy
+PP_940.2	Maternal care for transverse and oblique lie	Pregnancy
+PP_940.3	"Maternal care for face, brow and chin presentation"	Pregnancy
+PP_941	Abnormal forces of labor	Pregnancy
+PP_941.1	Uterine inertia	Pregnancy
+PP_941.2	Precipitate labor	Pregnancy
+PP_941.3	"Hypertonic, incoordinate, and prolonged uterine contractions"	Pregnancy
+PP_941.4	Long labor	Pregnancy
+PP_941.5	False labor	Pregnancy
+PP_944	Late pregnancy	Pregnancy
+PP_945	Rupture of uterus	Pregnancy
+PP_945.2	Rupture of uterus during labor	Pregnancy
+PP_945.3	Postpartum hemorrhage	Pregnancy
+PP_947	Umbilical cord complications	Pregnancy
+PP_947.1	Prolapse of cord complicating labor and delivery	Pregnancy
+PP_947.2	Short cord complicating labor and delivery	Pregnancy
+PP_947.3	Labor and delivery complicated by vasa previa	Pregnancy
+PP_947.4	Cord entanglement complicating labor and delivery	Pregnancy
+PP_947.5	Vascular lesions of cord complicating labor and delivery	Pregnancy
+PP_947.6	Velamentous insertion of umbilical cord*	Pregnancy
+PP_949	Complications of labor and delivery NEC	Pregnancy
+PP_949.1	Retained placenta or membranes	Pregnancy
+PP_949.2	Hypotension syndrome or shock during or following labor and delivery	Pregnancy
+PP_949.3	Postpartum acute kidney failure	Pregnancy
+PP_949.4	Maternal pyrexia during labor	Pregnancy
+PP_950	Puerperal infection or fever	Pregnancy
+PP_952	Other complications of the puerperium NEC	Pregnancy
+PP_952.5	Peripartum cardiomyopathy	Pregnancy
+PP_954	Disorders of the breast associated with childbirth and disorders of lactation	Pregnancy
+PP_954.2	Disorders of lactation	Pregnancy
+GE_960	Chromosomal anomalies	Genetic
+GE_960.1	Trisomies	Genetic
+GE_960.11	Down syndrome	Genetic
+GE_960.12	Trisomy 13 (Patau's syndrome)	Genetic
+GE_960.13	Trisomy 18 (Edwards' syndrome)	Genetic
+GE_960.14	Other whole chromosome trisomy*	Genetic
+GE_960.15	Partial trisomy*	Genetic
+GE_960.16	Duplications with other complex rearrangements*	Genetic
+GE_960.17	Marker chromosomes*	Genetic
+GE_960.2	Monosomies and chromosomal deletions	Genetic
+GE_960.21	DiGeorge/Velo-cardio-facial syndrome	Genetic
+GE_960.22	Williams syndrome*	Genetic
+GE_960.23	Whole chromosome monosomy*	Genetic
+GE_960.24	Deletion of short arm of chromosome 4*	Genetic
+GE_960.25	Deletion of short arm of chromosome 5 [Cri-du-chat syndrome]	Genetic
+GE_960.26	Ring chromosome*	Genetic
+GE_960.28	Other chromosomal microdeletions	Genetic
+GE_960.3	Sex chromosome anomalies	Genetic
+GE_960.31	Turner's syndrome	Genetic
+GE_960.32	Klinefelter's syndrome	Genetic
+GE_960.33	"Karyotype 47, XXX*"	Genetic
+GE_960.34	"Karyotype 46, XY*"	Genetic
+GE_960.35	"Karyotype 47, XYY*"	Genetic
+GE_960.36	"46, XX/46, XY*"	Genetic
+GE_960.5	Angelman syndrome*	Genetic
+GE_960.7	Prader-Willi syndrome	Genetic
+GE_960.8	Balanced rearrangements	Genetic
+GE_961	Genetic syndromes associated with neoplasms	Genetic
+GE_961.1	Phakomatoses	Genetic
+GE_961.11	Neurofibromatosis	Genetic
+GE_961.111	"Neurofibromatosis, type 1"	Genetic
+GE_961.112	"Neurofibromatosis, type 2"	Genetic
+GE_961.12	Tuberous sclerosis	Genetic
+GE_961.13	Von Hippel-Lindau syndrome*	Genetic
+GE_961.14	PTEN tumor syndrome*	Genetic
+GE_961.3	Incontinentia pigmenti*	Genetic
+GE_961.2	Multiple endocrine neoplasia [MEN] syndromes	Genetic
+GE_961.21	Multiple endocrine neoplasia [MEN] type I	Genetic
+GE_961.22	Multiple endocrine neoplasia [MEN] type IIA	Genetic
+GE_961.23	Multiple endocrine neoplasia [MEN] type IIB	Genetic
+GE_961.4	Schwannomatosis	Genetic
+GE_961.7	Ruvalcaba-Myhre-Smith syndrome*	Genetic
+GE_961.8	Genetic susceptibility to malignant neoplasm	Genetic
+GE_961.81	Genetic susceptibility to malignant neoplasm of breast	Genetic
+GE_961.82	Genetic susceptibility to malignant neoplasm of ovary	Genetic
+GE_961.83	Genetic susceptibility to malignant neoplasm of prostate	Genetic
+GE_961.84	Genetic susceptibility to malignant neoplasm of endometrium	Genetic
+GE_962	Disorders of amino-acid transport and metabolism	Genetic
+GE_962.1	Disorders of aromatic amino-acid metabolism	Genetic
+GE_962.11	Classical phenylketonuria	Genetic
+GE_962.12	Disorders of tyrosine metabolism*	Genetic
+GE_962.121	Tyrosinemia*	Genetic
+GE_962.13	Albinism*	Genetic
+GE_962.131	Ocular albinism*	Genetic
+GE_962.132	Chediak-Higashi syndrome*	Genetic
+GE_962.133	Hermansky-Pudlak syndrome*	Genetic
+GE_962.14	Disorders of histidine metabolism	Genetic
+GE_962.141	Histidinemia*	Genetic
+GE_962.15	Disorders of tryptophan metabolism*	Genetic
+GE_962.16	Aromatic L-amino acid decarboxylase deficiency (AADC definiciency)*	Genetic
+GE_962.2	Disturbances of branched-chain amino-acid metabolism	Genetic
+GE_962.21	Maple-syrup-urine disease*	Genetic
+GE_962.22	Isovaleric acidemia*	Genetic
+GE_962.23	3-methylglutaconic aciduria*	Genetic
+GE_962.24	Methylmalonic acidemia*	Genetic
+GE_962.25	Propionic acidemia*	Genetic
+GE_962.3	Disorders of fatty-acid metabolism	Genetic
+GE_962.31	Long chain/very long chain acyl CoA dehydrogenase deficiency*	Genetic
+GE_962.32	Medium chain acyl CoA dehydrogenase deficiency*	Genetic
+GE_962.33	Short chain acyl CoA dehydrogenase deficiency*	Genetic
+GE_962.34	Glutaric aciduria type II*	Genetic
+GE_962.38	Carnitine deficiency	Genetic
+GE_962.381	Primary carnitine deficiency	Genetic
+GE_962.35	Muscle carnitine palmitoyltransferase deficiency*	Genetic
+GE_962.39	Peroxisomal disorders	Genetic
+GE_962.391	Zellweger syndrome*	Genetic
+GE_962.392	Adrenoleukodystrophy*	Genetic
+GE_962.393	Rhizomelic chondrodysplasia punctata* [genetic]	Genetic
+GE_962.4	Disturbances of sulphur-bearing amino-acid metabolism	Genetic
+GE_962.41	Homocystinuria*	Genetic
+GE_962.42	Cystinuria*	Genetic
+GE_962.43	Methylenetetrahydrofolate reductase deficiency*	Genetic
+GE_962.5	Disorders of urea cycle metabolism	Genetic
+GE_962.51	Argininemia*	Genetic
+GE_962.52	Arginosuccinic aciduria*	Genetic
+GE_962.53	Citrullinemia*	Genetic
+GE_962.54	Disorders of ornithine metabolism*	Genetic
+GE_962.6	Disorders of lysine and hydroxylysine metabolism*	Genetic
+GE_962.7	Disorders of glycine metabolism*	Genetic
+GE_962.71	Trimethylaminuria*	Genetic
+GE_962.9	Disturbances of amino-acid transport	Genetic
+GE_962.94	Hartnup's disease*	Genetic
+GE_962.95	Lowe's syndrome*	Genetic
+GE_962.96	Cystinosis*	Genetic
+GE_963	Lysosomal storage disorders	Genetic
+GE_963.1	Lipid storage disorders	Genetic
+GE_963.11	Fabry disease*	Genetic
+GE_963.12	Gaucher disease*	Genetic
+GE_963.13	Krabbe disease*	Genetic
+GE_963.14	Niemann-Pick disease*	Genetic
+GE_963.141	Niemann-Pick disease type A*	Genetic
+GE_963.142	Niemann-Pick disease type B*	Genetic
+GE_963.143	Niemann-Pick disease type C*	Genetic
+GE_963.144	Niemann-Pick disease type D*	Genetic
+GE_963.15	Metachromatic leukodystrophy*	Genetic
+GE_963.16	Sulfatase deficiency*	Genetic
+GE_963.17	GM2 gangliosidosis	Genetic
+GE_963.171	Sandhoff disease*	Genetic
+GE_963.172	Tay-Sachs disease*	Genetic
+GE_963.18	Neuronal ceroid lipofuscinosis	Genetic
+GE_963.3	Mucopolysaccharidoses	Genetic
+GE_963.31	Hurler's syndrome [MPS IH]*	Genetic
+GE_963.32	Hurler-Scheie syndrome [MPS IH/S]*	Genetic
+GE_963.33	Scheie's syndrome [MPS Is]*	Genetic
+GE_963.34	"Mucopolysaccharidosis, type II*"	Genetic
+GE_963.35	"Mucopolysaccharidosis, type IVA*"	Genetic
+GE_963.36	"Mucopolysaccharidosis, type IVB*"	Genetic
+GE_963.37	Sanfilippo mucopolysaccharidoses*	Genetic
+GE_963.4	Mucolipidosis IV	Genetic
+GE_963.5	Disorders of glycoprotein metabolism [Glycoproteinoses]	Genetic
+GE_964	Disorders of carbohydrate metabolism	Genetic
+GE_964.1	Disorders of galactose metabolism	Genetic
+GE_964.11	Galactosemia (Classical and Duarte)	Genetic
+GE_964.2	Fructokinase deficiency	Genetic
+GE_964.21	Hereditary fructose intolerance	Genetic
+GE_964.3	Glycogen storage disease	Genetic
+GE_964.31	von Gierke disease*	Genetic
+GE_964.32	Pompe disease*	Genetic
+GE_964.33	Cori disease*	Genetic
+GE_964.34	McArdle disease*	Genetic
+GE_964.4	Sucrase-isomaltase deficiency*	Genetic
+GE_964.5	Disorders of pyruvate metabolism and gluconeogenesis*	Genetic
+GE_964.6	Glucose transporter protein type 1 deficiency (GLUT1 deficiency)*	Genetic
+GE_964.7	Congenital lactase deficiency*	Genetic
+GE_965	Inborn error of lipid metabolism	Genetic
+GE_965.1	Barth syndrome*	Genetic
+GE_965.2	Smith-Lemli-Opitz syndrome*	Genetic
+GE_965.3	Lipoprotein deficiencies	Genetic
+GE_965.4	Familial hypercholesterolemia*	Genetic
+GE_965.5	Refsum's disease	Genetic
+GE_966	Other inborn errors of metabolism	Genetic
+GE_966.1	Disorders of purine and pyrimidine metabolism	Genetic
+GE_966.11	Lesch-Nyhan syndrome*	Genetic
+GE_966.12	Myoadenylate deaminase deficiency*	Genetic
+GE_966.2	Disorders of porphyrin metabolism	Genetic
+GE_966.21	Hereditary erythropoietic porphyria*	Genetic
+GE_966.22	Porphyria cutanea tarda*	Genetic
+GE_966.23	Acute intermittent (hepatic) porphyria*	Genetic
+GE_966.3	Defects of catalase and peroxidase*	Genetic
+GE_966.4	Genetic of bilirubin excretion*	Genetic
+GE_966.41	Gilbert syndrome*	Genetic
+GE_966.42	Crigler-Najjar syndrome*	Genetic
+GE_967	Genetic disorders of vitamin and mineral metabolism	Genetic
+GE_967.1	Wilson's disease*	Genetic
+GE_967.2	Hereditary vitamin D-dependent rickets (type 1) (type 2)*	Genetic
+GE_967.3	Familial hypophosphatemia*	Genetic
+GE_967.4	Hereditary hemochromatosis	Genetic
+GE_967.5	Transcobalamin II deficiency*	Genetic
+GE_967.6	Biotinidase deficiency*	Genetic
+GE_968	Mitochondrial disorders	Genetic
+GE_968.1	MELAS syndrome*	Genetic
+GE_968.2	MERRF syndrome*	Genetic
+GE_968.3	Kearns-Sayre syndrome*	Genetic
+GE_968.4	Alpers disease*	Genetic
+GE_968.5	Leigh's disease*	Genetic
+GE_969	Genetic diseases of the immune system	Genetic
+GE_969.1	Primary immunodeficiencies	Genetic
+GE_969.11	Hereditary hypogammaglobulinemia	Genetic
+GE_969.12	Combined immunity deficiency	Genetic
+GE_969.121	Severe combined immunodeficiency due to adenosine deaminase deficiency*	Genetic
+GE_969.122	Adenosine deaminase 2 deficiency (DADA2)*	Genetic
+GE_969.123	Nezelof syndrome	Genetic
+GE_969.124	Purine nucleoside phosphorylase [PNP] deficiency*	Genetic
+GE_969.125	"Major histocompatibility complex class I deficiency (Bare lymphocyte syndrome, type I)*"	Genetic
+GE_969.126	"Major histocompatibility complex class II deficiency (Bare lymphocyte syndrome, type II)*"	Genetic
+GE_969.127	Activated Phosphoinositide 3-kinase Delta Syndrome [APDS]	Genetic
+GE_969.128	Severe combined immunodeficiency [SCID]*	Genetic
+GE_969.13	Wiskott-Aldrich syndrome	Genetic
+GE_969.14	Hyperimmunoglobulin E [IgE] syndrome*	Genetic
+GE_969.15	Lymphocyte function antigen-1 [LFA-1] defect*	Genetic
+GE_969.2	Autoimmune lymphoproliferative syndrome [ALPS]	Genetic
+GE_969.3	Genetic anomalies of leukocytes	Genetic
+GE_969.4	Hereditary alpha tryptasemia*	Genetic
+GE_969.5	Periodic fever syndromes	Genetic
+GE_969.6	Cryopyrin-associated periodic syndromes*	Genetic
+GE_969.7	Congenital agranulocytosis/neutropenia	Genetic
+GE_970	Hemoglobinopathies	Genetic
+GE_970.1	Sickle-cell disorders	Genetic
+GE_970.11	Sickle cell anemia (Hb-SS)	Genetic
+GE_970.12	Hemoglobin C disease	Genetic
+GE_970.14	Sickle-cell thalassemia	Genetic
+GE_970.2	Thalassemia	Genetic
+GE_970.21	Alpha thalassemia	Genetic
+GE_970.22	Beta thalassemia	Genetic
+GE_970.23	Delta thalassemia	Genetic
+GE_970.24	Hemoglobin E disease	Genetic
+GE_970.25	Thalassemia minor	Genetic
+GE_970.4	Methemoglobinemia	Genetic
+GE_970.5	Hereditary persistence of fetal hemoglobin [HPFH]*	Genetic
+GE_970.6	Hereditary hemolytic anemias	Genetic
+GE_970.61	Hereditary spherocytosis	Genetic
+GE_970.62	Hereditary elliptocytosis	Genetic
+GE_970.63	Disorders of glutathione metabolism	Genetic
+GE_970.631	Glucose-6-phosphate dehydrogenase [G6PD] deficiency*	Genetic
+GE_970.64	Hereditary hemolytic-uremic syndrome*	Genetic
+GE_970.65	Paroxysmal nocturnal hemoglobinuria [Marchiafava-Micheli]*	Genetic
+GE_970.66	Anemia due to disorders of glycolytic enzymes*	Genetic
+GE_970.661	Anemia due to pyruvate kinase deficiency*	Genetic
+GE_970.7	Congenital dyserythropoietic anemia*	Genetic
+GE_970.8	Hereditary sideroblastic anemia*	Genetic
+GE_971	Genetic coagulation defects	Genetic
+GE_971.1	Hereditary hypo-coagulability	Genetic
+GE_971.11	Hereditary factor VIII deficiency [Hemophilia A]	Genetic
+GE_971.12	Hereditary factor IX disorder [Hemophilia B]	Genetic
+GE_971.13	Factor XI deficiency [Hemophilia C]	Genetic
+GE_971.14	Von Willebrand's disease	Genetic
+GE_971.2	Prothrombin gene mutation*	Genetic
+GE_972	Genetic neuromuscular disease	Genetic
+GE_972.1	Hereditary neuropathy	Genetic
+GE_972.11	Hereditary motor and sensory neuropathy	Genetic
+GE_972.2	Hereditary ataxia	Genetic
+GE_972.21	Hereditary spastic paraplegia	Genetic
+GE_972.22	Friedreich ataxia*	Genetic
+GE_972.4	Spinal muscular atrophy and related syndromes	Genetic
+GE_972.41	Spinal muscular atrophy	Genetic
+GE_972.411	"Spinal muscular atrophy, type I [Werdnig-Hoffman]"	Genetic
+GE_972.412	Progressive spinal muscle atrophy*	Genetic
+GE_972.42	Familial motor neuron disease*	Genetic
+GE_972.5	Familial dysautonomia [Riley-Day]*	Genetic
+GE_972.7	Genetic torsion dystonia	Genetic
+GE_972.8	Genetic myotonic disorders	Genetic
+GE_972.81	Myotonic muscular dystrophy	Genetic
+GE_972.82	Myotonia congenita	Genetic
+GE_972.83	Myotonic chondrodystrophy	Genetic
+GE_972.9	Muscular dystrophy	Genetic
+GE_972.91	Duchenne or Becker muscular dystrophy*	Genetic
+GE_972.92	Facioscapulohumeral muscular dystrophy*	Genetic
+GE_972.93	Nemaline myopathy*	Genetic
+GE_972.94	Centronuclear myopathy*	Genetic
+GE_972.941	X-linked myotubular myopathy*	Genetic
+GE_973	Genetic neurological disorders	Genetic
+GE_973.1	Dravet syndrome*	Genetic
+GE_973.2	Cyclin-Dependent Kinase-Like 5 Deficiency Disorder*	Genetic
+GE_973.3	Genetic related intellectual disability*	Genetic
+GE_973.31	SYNGAP1-related intellectual disability*	Genetic
+GE_973.4	Fragile X syndrome	Genetic
+GE_973.5	Huntington's disease	Genetic
+GE_973.6	Fatal familial insomnia	Genetic
+GE_973.8	Hallervorden-Spatz disease [PKAN]*	Genetic
+GE_974	Genetic diseases of the eye	Genetic
+GE_974.1	Hereditary retinal dystrophy	Genetic
+GE_974.11	Pigmentary retinal dystrophy	Genetic
+GE_974.12	Vitreoretinal dystrophy	Genetic
+GE_974.2	Hereditary corneal dystrophies	Genetic
+GE_974.22	Lattice corneal dystrophy	Genetic
+GE_974.23	Granular corneal dystrophy	Genetic
+GE_974.24	Juvenile epithelial corneal dystrophy [Meesmann corneal dystrophy]	Genetic
+GE_974.25	Macular corneal dystrophy*	Genetic
+GE_974.3	Hereditary choroidal dystrophies	Genetic
+GE_974.31	Choroideremia	Genetic
+GE_974.4	Hereditary optic atrophy	Genetic
+GE_975	Hereditary cardiovascular diseases	Genetic
+GE_975.1	Cerebral autosomal dominant arteriopathy with subcortical infarcts and leukoencephalopathy [CADASIL]*	Genetic
+GE_975.2	Hereditary hemorrhagic telangiectasia	Genetic
+GE_975.3	Arterial tortuosity syndrome*	Genetic
+GE_976	Genetic diseases primary affecting the kidneys	Genetic
+GE_976.1	Hereditary nephropathy*	Genetic
+GE_976.2	Bartter's syndrome	Genetic
+GE_976.3	Primary hyperoxaluria*	Genetic
+GE_976.4	Alport syndrome*	Genetic
+GE_976.5	Polycystic kidney disease	Genetic
+GE_976.51	Autosomal recessive polycystic kidney disease (ARPKD)	Genetic
+GE_976.52	Autosomal dominant polycystic kidney disease (ADPKD)	Genetic
+GE_977	Genetic disorders of skin	Genetic
+GE_977.1	Congenital ichthyosis	Genetic
+GE_977.11	Ichthyosis vulgaris*	Genetic
+GE_977.12	X-linked ichthyosis*	Genetic
+GE_977.13	Lamellar ichthyosis*	Genetic
+GE_977.14	Congenital bullous ichthyosiform erythroderma*	Genetic
+GE_977.15	Harlequin fetus*	Genetic
+GE_977.2	Epidermolysis bullosa*	Genetic
+GE_977.3	Xeroderma pigmentosum*	Genetic
+GE_977.5	Ectodermal dysplasia	Genetic
+GE_977.6	Congenital cutaneous mastocytosis*	Genetic
+GE_977.7	Steatocystoma multiplex*	Genetic
+GE_978	Genetic disorders relating to growth and musculoskeletal system	Genetic
+GE_978.1	Genetic causes of short stature*	Genetic
+GE_978.11	Primary insulin-like growth factor-1 (IGF-1) deficiency*	Genetic
+GE_978.12	Congenital adrenogenital disorders associated with enzyme deficiency*	Genetic
+GE_978.2	Herediatary connective tissue diseases	Genetic
+GE_978.21	Marfan syndrome	Genetic
+GE_978.22	Ehler's Danlos syndrome	Genetic
+GE_978.221	Classical Ehlers-Danlos syndrome*	Genetic
+GE_978.222	Vascular Ehlers-Danlos syndrome*	Genetic
+GE_978.3	Osteochondrodysplasias	Genetic
+GE_978.31	Chondrodystrophy	Genetic
+GE_978.312	Hypochondrogenesis*	Genetic
+GE_978.313	Thanatophoric short stature*	Genetic
+GE_978.314	Achondroplasia*	Genetic
+GE_978.315	Diastrophic dysplasia*	Genetic
+GE_978.316	Spondyloepiphyseal dysplasia*	Genetic
+GE_978.32	Chondroectodermal dysplasia [genetic]	Genetic
+GE_978.33	Osteogenesis imperfecta [genetic]	Genetic
+GE_978.34	Osteopetrosis [genetic]	Genetic
+GE_978.35	Polyostotic fibrous dysplasia	Genetic
+GE_978.36	Progressive diaphyseal dysplasia [Multiple epiphyseal dysplasia]	Genetic
+GE_978.37	Multiple congenital exostoses*	Genetic
+GE_978.4	Familial chondrocalcinosis*	Genetic
+GE_979	Genetic disorders primarily affecting lungs	Genetic
+GE_979.1	Surfactant mutations of the lung	Genetic
+GE_979.2	Cystic fibrosis	Genetic
+GE_981	Other genetic disesaes	Genetic
+GE_981.1	Alpha-1-antitrypsin deficiency	Genetic
+GE_981.2	Plasminogen deficiency*	Genetic
+GE_981.3	Rett syndrome*	Genetic
+GE_981.4	Pseudohypoparathyroidism*	Genetic
+GE_981.5	Familial Mediterranean fever	Genetic
+GE_981.7	Familial polycythemia [Familial erythrocytosis]	Genetic
+GE_981.8	Malignant hyperthermia	Genetic
+GE_981.9	Androgen insensitivity syndrome	Genetic
+GE_982	"Genetic susceptibility of disease, NOS"	Genetic
+GE_983	Genetic carrier status	Genetic
+GE_983.1	Cystic fibrosis carrier	Genetic
+GE_983.2	Hemoglobin C trait [Sickle-cell trait]	Genetic

--- a/src/drive/plugins/network_writer.py
+++ b/src/drive/plugins/network_writer.py
@@ -119,7 +119,7 @@ class NetworkWriter:
             output_str = ", ".join(category_not_found)
             available_vals = ", ".join(phecodeDesc.category_groups.keys())
             logger.critical(
-                f"categories, {output_str} not found in the list of categories. Allowed values are: {available_vals}"
+                f"categories, {output_str}, were not found in the list of categories. Allowed values are: {available_vals}"
             )
             raise ValueError(
                 f"categories {output_str} not found. Please check spelling of the phecode category"
@@ -138,6 +138,12 @@ class NetworkWriter:
                 [value for value in phecode_cols if value in phecodes_in_category]
             )
 
+        if len(return_list) == 0:
+            phecode_str = ", ".join(categories_to_keep)
+            logger.fatal(
+                f"There were no phecodes from the provided phenotype file that fell into the PheWAS defined categories: {phecode_str}. This error probably indicates you are using multiple custom phecode columns and DRIVE is unable to filter for custom phecode columns"
+            )
+            sys.exit(1)
         return return_list
 
     def analyze(self, **kwargs) -> None:

--- a/src/drive/plugins/pvalues.py
+++ b/src/drive/plugins/pvalues.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
+from drive.utilities.parser.phenotype_descriptions_parser import PhecodesMapper
 from log import CustomLogger
 from numpy import float64
 from scipy.stats import binomtest
@@ -322,9 +323,7 @@ class Pvalues:
         return cur_min_pvalue, cur_min_phenotype, phenotype_pvalues
 
     @staticmethod
-    def _get_descriptions(
-        phecode_description: dict[str, dict[str, str]], min_phecode: str
-    ) -> str:
+    def _get_descriptions(phecode_description: PhecodesMapper, min_phecode: str) -> str:
         """Method to get the description for the minimum phecode
         Parameters
         ----------
@@ -342,13 +341,7 @@ class Pvalues:
             returns a string that has the phecode description
         """
         # getting the description
-        desc_dict = phecode_description.get(min_phecode, {})
-
-        # getting the phenotype string if key exists,
-        # otherwise returns an empty string
-        logger.debug(f"description_str = {desc_dict.get('phenotype', 'N/A')}")
-
-        return desc_dict.get("phenotype", "N/A")
+        return phecode_description.phecode_names.get(min_phecode, "N/A")
 
     def analyze(self, **kwargs) -> None:
         # this is the DataHolder model. We will use the networks, the

--- a/src/drive/utilities/parser/__init__.py
+++ b/src/drive/utilities/parser/__init__.py
@@ -1,6 +1,6 @@
 # isort: skip_file
 from .case_file_parser import PhenotypeFileParser
-from .phenotype_descriptions_parser import load_phenotype_descriptions
+from .phenotype_descriptions_parser import load_phenotype_descriptions, PhecodesMapper
 from .cmdline_parser import (
     generate_cmd_parser,
 )  # This import needs to come after the load_phenotype_descriptions to avoid a circular import. Isort would change this which is why this file is skipped

--- a/src/drive/utilities/parser/cmdline_parser.py
+++ b/src/drive/utilities/parser/cmdline_parser.py
@@ -222,6 +222,14 @@ def generate_cmd_parser() -> argparse.ArgumentParser:
         help="whether or not to compress the output file from the DRIVE clustering output file. When the program is run PhenomeWide, the output file can be quite large. This option helps make file storage more managable",
     )
 
+    cluster_parser.add_argument(
+        "--phecode-categories-to-keep",
+        required=False,
+        nargs="+",
+        type=str,
+        help="List of phecode categories to write to the output file. This flag is only useful if you are running DRIVE phenomewide and if you are running DRIVE with phecodeX. DRIVE will calculate pvalues for all phecodes by default. This flag will check to see if the PheCode Category prefix (such as the CV prefix for cardiovascular phecodes) and only return those phecodes that match. Even with this flag, DRIVE will still return the phenomewide minimum phecode across all the different phecodes.",
+    )
+
     cluster_parser.set_defaults(func=run_network_identification)
 
     # This is where we will define all of the necessary arguments to make

--- a/src/drive/utilities/parser/cmdline_parser.py
+++ b/src/drive/utilities/parser/cmdline_parser.py
@@ -143,13 +143,6 @@ def generate_cmd_parser() -> argparse.ArgumentParser:
     )
 
     cluster_parser.add_argument(
-        "--descriptions",
-        "-d",
-        type=Path,
-        help="tab delimited text file that has descriptions for each phecode. this file should have two columns called phecode and phenotype",  # noqa: E501
-    )
-
-    cluster_parser.add_argument(
         "--max-network-size",
         default=30,
         type=int,

--- a/src/drive/utilities/parser/phenotype_descriptions_parser.py
+++ b/src/drive/utilities/parser/phenotype_descriptions_parser.py
@@ -45,9 +45,14 @@ def load_phenotype_descriptions(
 
     for file in phecode_map_files:
         with open(file, "r") as phecode_file:
+            header = next(phecode_file)
             csvreader = csv.reader(phecode_file, delimiter="\t", quotechar='"')
             for line in csvreader:
                 phecodeid, desc, category = line
+                # There are phecodes in the 1000+ range that have no category.
+                # We will use the phrase other here
+                if category == "NULL":
+                    category = "Other"
                 phecode_container.phecode_names[phecodeid] = desc
                 phecode_container.category_groups.setdefault(category, []).append(
                     phecodeid

--- a/tests/test_inputs/test_phenotype_file_withNAs.txt
+++ b/tests/test_inputs/test_phenotype_file_withNAs.txt
@@ -1,4 +1,4 @@
-GRID	phenoA	phenoB	phenoC
+GRID	CV_414	NS_324.11	phenoC
 905	0	0	0
 865	0	0	0
 890	0	1	0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,9 +14,6 @@ from drive import drive
 site_packages_path = Path(sysconfig.get_paths().get("platlib"))
 
 
-# @pytest.mark.integtest
-# def test_drive_full_run():
-#     assert 1==1
 @pytest.fixture()
 def system_args_no_pheno(monkeypatch):
     input_file = (
@@ -162,6 +159,7 @@ def system_args_for_dendrogram(monkeypatch):
 def test_drive_full_run_no_phenotypes(system_args_no_pheno):
     # Make sure the output directory exists
     output_path = site_packages_path / "tests/test_output"
+    print(output_path)
     output_path.mkdir(exist_ok=True)
 
     drive.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -159,7 +159,6 @@ def system_args_for_dendrogram(monkeypatch):
 def test_drive_full_run_no_phenotypes(system_args_no_pheno):
     # Make sure the output directory exists
     output_path = site_packages_path / "tests/test_output"
-    print(output_path)
     output_path.mkdir(exist_ok=True)
 
     drive.main()

--- a/tests/test_phenotype_file_parser.py
+++ b/tests/test_phenotype_file_parser.py
@@ -25,7 +25,7 @@ def test_check_separator(test_str: str, expected: str) -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("test_str", [("ID1\n1")])
+@pytest.mark.parametrize("test_str", ["ID1\n1"])
 def test_check_separator_error(test_str: str) -> None:
     """Test that the method _check_separator raises a ValueError if it cannot identify the separator."""
     with pytest.raises(ValueError):


### PR DESCRIPTION
Updated phenotype description parser to automatically load the phecode descriptions without having the user provide them. Now DRIVE will automatically annotate the most enriched phenotype with the appropriate descriptor if the user is using phecodes from 1.2 or X. This change also makes it easier for users to specify which phecode categories to keep. Instead of having to specify a prefix now they can just use the prefix as specified in the PheWAS catalogue. This method still doesn't support filtering custom phenotypes, but I doubt the user would be running enough custom phenotypes that this will matter