### PR TITLE
docs(expected_plugin_structure.rst): updated comments in example plugin code to show where user should add code

### DIFF
--- a/docs/source/plugin_descriptions/expected_plugin_structure.rst
+++ b/docs/source/plugin_descriptions/expected_plugin_structure.rst
@@ -41,7 +41,8 @@ A template for the plugin class is shown below. The example uses dataclasses but
 
         def analyze(self, **kwargs) -> None:
             """This is the main function that DRIVE will use to interact with 
-            the plugin. This function is required and has to be called analyze"""
+            the plugin. This function is required and has to be called analyze. 
+            Users should fill in this section to create their own plugin"""
 
             ...
 
@@ -49,10 +50,10 @@ A template for the plugin class is shown below. The example uses dataclasses but
     # The pluging file needs to have a function at the end called initialize. This 
     # function is used by the plugin factory to dynamically run the code at runtime.
     def initialize() -> None:
-        factory_register("plugin_name from the file name", PluginName)
+        factory_register("plugin_name from the file name", PluginName) #If the file is CustomPlugin.py then the plugin name here would be "CustomPlugin"
 
-Where the plugins have to be place:
------------------------------------
+Where the plugins have to be located in the file system:
+--------------------------------------------------------
 DRIVE expects the code for the plugins to be located in a module within the DRIVE source code directory. Within this source code there is a subdirectory call plugins. This directory is where DRIVE will look for the plugin code.
 
 .. attention::


### PR DESCRIPTION
The phrasing for where users should put their own code in the plugin was not quite clear. I added a statement saying which method the user should put their code into. Additionally I added a comment that describes how to figure out what the plugin name needed for the initialize method should be based on the file name